### PR TITLE
fix(app): KR per-game overrides & library delete fix + deprecation cleanup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,7 +46,7 @@ android {
     // 引擎原生插件作为 assets 打包，首次启动自动安装到 app 私有目录
     sourceSets {
       getByName("main") {
-        assets.srcDir("src/main/nativeplugins")
+        assets.srcDirs("src/main/nativeplugins")
       }
     }
 }

--- a/app/src/main/java/com/tyranor/next/MainActivity.kt
+++ b/app/src/main/java/com/tyranor/next/MainActivity.kt
@@ -1,6 +1,5 @@
 package com.tyranor.next
 
-import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -26,9 +25,7 @@ class MainActivity : ComponentActivity() {
       navigationBarStyle = androidx.activity.SystemBarStyle.light(android.graphics.Color.TRANSPARENT, android.graphics.Color.TRANSPARENT),
     )
 
-    // 状态栏/导航栏透明沉浸，顶部栏(页面背景色)与底部导航背景向上/向下延伸
-    window.statusBarColor = Color.TRANSPARENT
-    window.navigationBarColor = Color.TRANSPARENT
+    // 状态栏/导航栏透明沉浸由 enableEdgeToEdge(transparent) 处理，无需再设置已弃用的 window.statusBarColor
 
     setContent {
       TyranorNextTheme { Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) { MainNavigation() } }

--- a/app/src/main/java/com/tyranor/next/scanner/EngineLauncher.kt
+++ b/app/src/main/java/com/tyranor/next/scanner/EngineLauncher.kt
@@ -209,9 +209,13 @@ object EngineLauncher {
             if (defaultFont.isNotEmpty()) putExtra("default_font", defaultFont)
             if (forceFont) putExtra("force_default_font", true)
             // 渲染/内存偏好 JSON：单游戏覆盖 与 全局 逐键合并
+            // 注意：buildKrEnginePrefsJson 遍历的是全局键（kr_renderer 等），
+            // 而单游戏覆盖以 PerGameSettingsStore.KR_FIELDS（renderer 等）存储，需做键名映射。
             runCatching {
-                putExtra("krkr_engine_prefs", EngineSettingsStore.buildKrEnginePrefsJson(context) { key ->
-                    PerGameSettingsStore.getStr(context, gid, key)
+                val renderKeyMap = EngineSettingsStore.KR_RENDER_PREF_KEYS
+                    .zip(PerGameSettingsStore.KR_FIELDS).toMap()
+                putExtra("krkr_engine_prefs", EngineSettingsStore.buildKrEnginePrefsJson(context) { globalKey ->
+                    renderKeyMap[globalKey]?.let { PerGameSettingsStore.getStr(context, gid, it) }
                 })
             }
         }

--- a/app/src/main/java/com/tyranor/next/scanner/EngineScanner.kt
+++ b/app/src/main/java/com/tyranor/next/scanner/EngineScanner.kt
@@ -94,6 +94,11 @@ object EngineScanner {
         saveRecentGames(context, loadRecentGames(context).filterNot { it.uri == uri })
     }
 
+    /** 从持久游戏库中移除指定游戏（在游戏页或首页删除游戏时调用，保证库与最近列表一致）。 */
+    fun removeGame(context: Context, uri: String) {
+        saveGames(context, loadGames(context).filterNot { it.uri == uri })
+    }
+
     private fun saveRecentGames(context: Context, games: List<ScanGame>) {
         val str = games.joinToString("\n") { serializeGame(it) }
         context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
@@ -165,7 +170,7 @@ object EngineScanner {
 
     private fun traverseDirectories(context: Context, dir: DocumentFile, level: Int, out: MutableList<ScanGame>) {
         if (level > 3) return
-        val children = dir.listFiles() ?: return
+        val children = dir.listFiles()
 
         // 1) 本级目录本身可能是游戏（含引擎特征文件）
         val detected = detectEngine(dir)
@@ -197,8 +202,8 @@ object EngineScanner {
 
     fun detectEngine(dir: DocumentFile): Detection {
         val r = Detection(EngineType.UNKNOWN, 0, "")
-        if (dir == null || !dir.isDirectory) return r
-        val children = dir.listFiles() ?: return r
+        if (!dir.isDirectory) return r
+        val children = dir.listFiles()
 
         val names = HashSet<String>()            // 小写名
         val xp3Files = mutableListOf<String>()
@@ -226,7 +231,7 @@ object EngineScanner {
                     lower == "system" || lower == "app" || lower == "game" || lower == "resources"
                 ) {
                     val sub = f.listFiles()
-                    sub?.forEach { collect(it, childRel) }
+                    sub.forEach { collect(it, childRel) }
                 }
                 return
             }

--- a/app/src/main/java/com/tyranor/next/settings/EngineSettingsStore.kt
+++ b/app/src/main/java/com/tyranor/next/settings/EngineSettingsStore.kt
@@ -80,7 +80,7 @@ object EngineSettingsStore {
 
     fun getKrKernel(c: Context): String {
         val v = prefs(c).getString(KEY_KR_ENGINE_KERNEL, KR_AUTO)
-        return when (v) { KERNEL_KIRIKIRI2, KERNEL_KRKRSDL3 -> v!!; else -> KR_AUTO }
+        return when (v) { KERNEL_KIRIKIRI2, KERNEL_KRKRSDL3 -> v; else -> KR_AUTO }
     }
     fun setKrKernel(c: Context, v: String) = prefs(c).edit().putString(KEY_KR_ENGINE_KERNEL, v).apply()
 
@@ -174,7 +174,7 @@ object EngineSettingsStore {
 
     fun saveOns(c: Context, o: Ons) = onsPrefs(c).edit().putString("gameargs", o.toJson()).apply()
 
-    fun normalizeEncoding(v: String): String = when (v?.trim()?.lowercase()) {
+    fun normalizeEncoding(v: String): String = when (v.trim().lowercase()) {
         "utf8", "utf-8" -> "utf8"
         "sjis", "shift-jis", "shift_jis" -> "sjis"
         else -> "gbk"

--- a/app/src/main/java/com/tyranor/next/ui/pages/HomeScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/pages/HomeScreen.kt
@@ -45,6 +45,8 @@ fun HomeScreen(modifier: Modifier = Modifier) {
     fun deleteGame(target: ScanGame) {
         recentGames = recentGames.filterNot { it.uri == target.uri }
         selectedGame = null
+        // 从持久游戏库一并移除，避免首页删了但「游戏」页仍显示（复活）
+        EngineScanner.removeGame(context, target.uri)
         // 仅清理应用内数据（每游戏设置、最近记录、封面缓存、应用内存档镜像）；不触碰游戏文件
         scope.launch(Dispatchers.IO) {
             cleanupDeletedGame(context, target)

--- a/app/src/main/java/com/tyranor/next/ui/pages/PerGameSettingsActivity.kt
+++ b/app/src/main/java/com/tyranor/next/ui/pages/PerGameSettingsActivity.kt
@@ -23,8 +23,7 @@ class PerGameSettingsActivity : ComponentActivity() {
             statusBarStyle = androidx.activity.SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT),
             navigationBarStyle = androidx.activity.SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT),
         )
-        window.statusBarColor = Color.TRANSPARENT
-        window.navigationBarColor = Color.TRANSPARENT
+        // 状态栏/导航栏透明沉浸由 enableEdgeToEdge(transparent) 处理，无需再设置已弃用的 window.statusBarColor
 
         val game = intent.readScanGame()
         if (game == null) {

--- a/app/src/main/java/com/tyranor/next/ui/pages/SettingsScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/pages/SettingsScreen.kt
@@ -226,7 +226,7 @@ internal fun EngineSettingsDetailScreen(kind: EngineSettingsKind) {
     }
 }
 
-enum class EngineSettingsKind(val title: String, @DrawableRes val iconRes: Int) {
+enum class EngineSettingsKind(val title: String, @param:DrawableRes val iconRes: Int) {
     KRKR("KRKR引擎设置", R.drawable.ic_engine_item),
     ONS("ONS引擎设置", R.drawable.ic_engine_item),
     ARTEMIS("Artemis引擎设置", R.drawable.ic_engine_item),


### PR DESCRIPTION
## 概述
针对 `app` 模块做了一轮调试与代码质量清理（未改动 `engine` 原生运行时胶水层）。编译已验证通过（`assembleDebug` BUILD SUCCESSFUL，且 `app` 模块相关编译器弃用告警已清零）。

## 修复
1. **KR 单游戏「渲染器/内存」等覆盖被静默丢弃**（严重）
   - 之前 `buildKrEnginePrefsJson` 用全局键（`kr_renderer` 等）去查询单游戏覆盖，而 `PerGameSettingsStore` 以不同键（`renderer` 等）存储，导致 `overrideGetter` 永远返回 `null`，单游戏 KR 渲染/内存设置从不生效。
   - 修复：在 `EngineLauncher` 调用处把全局键映射到单游戏键（`EngineSettingsStore.KR_RENDER_PREF_KEYS` ↔ `PerGameSettingsStore.KR_FIELDS`）。
2. **首页删除游戏未从持久游戏库移除**（严重）
   - `HomeScreen.deleteGame` 只清了「最近」列表，未更新 `EngineScanner` 持久游戏库，游戏在「游戏」页仍然存在（刷新后复活）。
   - 修复：新增 `EngineScanner.removeGame()`，并在首页删除时调用，使持久库与最近列表一致。

## 重构 / 质量
- `build.gradle.kts`：`assets.srcDir` → `assets.srcDirs`（弃用 API）。
- `SettingsScreen`：`@DrawableRes` 加上 `@param:` 注解目标，避免未来字段应用告警。
- `MainActivity` / `PerGameSettingsActivity`：移除与 `enableEdgeToEdge(transparent)` 重复的已弃用 `window.statusBarColor` 赋值。
- `EngineSettingsStore` / `EngineScanner`：移除不必要的 `!!` 与安全调用；`DocumentFile.listFiles()` 不会返回 `null`，去掉恒假 `dir == null` 检查与多余的 elvis/安全调用。

## 验证
- `./gradlew assembleDebug` 构建通过；`app` 模块编译器告警已消除。
- 未改动 `engine` 原生运行时；`lintDebug` 报告的 34 error/68 warning 全部位于 `engine` 的第三方 vendor 代码（SDL/SDL3 等），与本次改动无关、不在范围内。

## 备注
如需，我可另开一个 PR 为仓库补一个最小化的 GitHub Actions CI（仅跑 `assembleDebug`），因为目前仓库没有 CI 配置。