### PR TITLE
fix+refactor(app): 生命周期与删除清理修复、去重与 lint 修复

### DIFF
--- a/app/src/main/java/com/tyranor/next/scanner/EngineLauncher.kt
+++ b/app/src/main/java/com/tyranor/next/scanner/EngineLauncher.kt
@@ -130,7 +130,7 @@ object EngineLauncher {
                 }
                 if (ons.sharpness) {
                     args.add("--sharpness")
-                    args.add(ons.sharpnessValue)
+                    args.add(safeSharpnessValue(ons.sharpnessValue))
                 }
                 Intent(context, ONScripter::class.java).apply {
                     putStringArrayListExtra("gameargs", args)
@@ -389,6 +389,16 @@ object EngineLauncher {
         val name = runCatching { File(rootPath).name.takeIf { it.isNotBlank() } }.getOrNull()
             ?: abs(rootPath.hashCode()).toString()
         return name.replace(Regex("[\\\\/:*?\"<>|]"), "_").trim().ifEmpty { "default" }
+    }
+
+    /** 与 OnsSettings.safeSharpness 一致：只接受 0.1~10.0 的数字，否则回退 "2"。 */
+    private fun safeSharpnessValue(value: String): String {
+        val v = value.trim()
+        if (v.isEmpty()) return "2"
+        val parsed = v.toDoubleOrNull() ?: return "2"
+        if (parsed.isNaN() || parsed.isInfinite()) return "2"
+        if (parsed < 0.1 || parsed > 10.0) return "2"
+        return v
     }
 
     /**

--- a/app/src/main/java/com/tyranor/next/scanner/EngineLauncher.kt
+++ b/app/src/main/java/com/tyranor/next/scanner/EngineLauncher.kt
@@ -19,7 +19,6 @@ import com.tyranor.next.settings.EngineSettingsStore
 import com.tyranor.next.settings.PerGameSettingsStore
 import com.yuri.onscripter.ONScripter
 import java.io.File
-import kotlin.math.abs
 
 /**
  * 游戏引擎启动器：根据 [EngineType] 把扫描到的游戏目录交给对应引擎宿主 Activity。
@@ -205,7 +204,7 @@ object EngineLauncher {
                 context.filesDir?.let { internal ->
                     putExtra(
                         "scopedSaveRoot",
-                        File(File(File(internal, "krkr_mirror"), safeSaveName(path)), "savedata").absolutePath,
+                        File(File(File(internal, "krkr_mirror"), EngineScanner.safeSaveName(path)), "savedata").absolutePath,
                     )
                 }
             }
@@ -294,7 +293,7 @@ object EngineLauncher {
             ?: EngineSettingsStore.isTyranoScopedSaveDir(context)
         val scopedSaveRoot = if (scoped) {
             context.getExternalFilesDir(null)?.let { external ->
-                File(File(File(external, "save"), "tyrano"), safeSaveName(path)).absolutePath
+                File(File(File(external, "save"), "tyrano"), EngineScanner.safeSaveName(path)).absolutePath
             }
         } else {
             null
@@ -383,12 +382,6 @@ object EngineLauncher {
         val path = resolveGameDirectory(context, game) ?: return null
         val entry = pickKrActivateEntry(path, game)
         return java.io.File(entry).takeIf { it.isFile }?.name
-    }
-
-    private fun safeSaveName(rootPath: String): String {
-        val name = runCatching { File(rootPath).name.takeIf { it.isNotBlank() } }.getOrNull()
-            ?: abs(rootPath.hashCode()).toString()
-        return name.replace(Regex("[\\\\/:*?\"<>|]"), "_").trim().ifEmpty { "default" }
     }
 
     /** 与 OnsSettings.safeSharpness 一致：只接受 0.1~10.0 的数字，否则回退 "2"。 */

--- a/app/src/main/java/com/tyranor/next/scanner/EngineScanner.kt
+++ b/app/src/main/java/com/tyranor/next/scanner/EngineScanner.kt
@@ -69,17 +69,9 @@ object EngineScanner {
 
     // ============ 游戏结果持久化 ============
 
-    fun saveGames(context: Context, games: List<ScanGame>) {
-        val str = games.joinToString("\n") { serializeGame(it) }
-        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-            .edit().putString(KEY_GAMES, str).apply()
-    }
+    fun saveGames(context: Context, games: List<ScanGame>) = saveList(context, KEY_GAMES, games)
 
-    fun loadGames(context: Context): List<ScanGame> {
-        val raw = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-            .getString(KEY_GAMES, null) ?: return emptyList()
-        return raw.split("\n").mapNotNull { parseGame(it) }
-    }
+    fun loadGames(context: Context): List<ScanGame> = loadList(context, KEY_GAMES)
 
     fun recordRecentGame(context: Context, game: ScanGame) {
         val touched = game.copy(openTime = System.currentTimeMillis())
@@ -87,11 +79,7 @@ object EngineScanner {
         saveRecentGames(context, next)
     }
 
-    fun loadRecentGames(context: Context): List<ScanGame> {
-        val raw = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-            .getString(KEY_RECENT_GAMES, null) ?: return emptyList()
-        return raw.split("\n").mapNotNull { parseGame(it) }
-    }
+    fun loadRecentGames(context: Context): List<ScanGame> = loadList(context, KEY_RECENT_GAMES)
 
     /** 删除游戏时从最近游戏列表中移除对应条目。 */
     fun removeRecentGame(context: Context, uri: String) {
@@ -110,19 +98,12 @@ object EngineScanner {
         return name.replace(Regex("[\\\\/:*?\"<>|]"), "_").trim().ifEmpty { "default" }
     }
 
-    internal fun saveRecentGames(context: Context, games: List<ScanGame>) {
-        val str = games.joinToString("\n") { serializeGame(it) }
-        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-            .edit().putString(KEY_RECENT_GAMES, str).apply()
-    }
+internal fun saveRecentGames(context: Context, games: List<ScanGame>) =
+        saveList(context, KEY_RECENT_GAMES, games)
 
     // ============ 首页快捷启动（最多 3 个） ============
 
-    fun loadQuickLaunch(context: Context): List<ScanGame> {
-        val raw = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-            .getString(KEY_QUICK_LAUNCH, null) ?: return emptyList()
-        return raw.split("\n").mapNotNull { parseGame(it) }
-    }
+    fun loadQuickLaunch(context: Context): List<ScanGame> = loadList(context, KEY_QUICK_LAUNCH)
 
     fun isQuickLaunched(context: Context, uri: String): Boolean =
         loadQuickLaunch(context).any { it.uri == uri }
@@ -152,10 +133,21 @@ object EngineScanner {
         return refreshed
     }
 
-    internal fun saveQuickLaunch(context: Context, games: List<ScanGame>) {
+    internal fun saveQuickLaunch(context: Context, games: List<ScanGame>) =
+        saveList(context, KEY_QUICK_LAUNCH, games)
+
+    // ---------- 通用存取助手 ----------
+
+    private fun saveList(context: Context, key: String, games: List<ScanGame>) {
         val str = games.joinToString("\n") { serializeGame(it) }
         context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-            .edit().putString(KEY_QUICK_LAUNCH, str).apply()
+            .edit().putString(key, str).apply()
+    }
+
+    private fun loadList(context: Context, key: String): List<ScanGame> {
+        val raw = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .getString(key, null) ?: return emptyList()
+        return raw.split("\n").mapNotNull { parseGame(it) }
     }
 
     private fun serializeGame(g: ScanGame): String {

--- a/app/src/main/java/com/tyranor/next/scanner/EngineScanner.kt
+++ b/app/src/main/java/com/tyranor/next/scanner/EngineScanner.kt
@@ -6,7 +6,9 @@ import android.provider.DocumentsContract
 import androidx.documentfile.provider.DocumentFile
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.io.File
 import java.util.Locale
+import kotlin.math.abs
 
 /**
  * 精简版游戏扫描器，识别逻辑移植自 RinneMobile 的 EngineDetector/GameScanner。
@@ -99,6 +101,13 @@ object EngineScanner {
     /** 从持久游戏库中移除指定游戏（在游戏页或首页删除游戏时调用，保证库与最近列表一致）。 */
     fun removeGame(context: Context, uri: String) {
         saveGames(context, loadGames(context).filterNot { it.uri == uri })
+    }
+
+/** 目录名 → 安全文件名（用于应用内镜像/独立存档目录），非法字符替换为下划线。 */
+    fun safeSaveName(rootPath: String): String {
+        val name = runCatching { File(rootPath).name.takeIf { it.isNotBlank() } }.getOrNull()
+            ?: abs(rootPath.hashCode()).toString()
+        return name.replace(Regex("[\\\\/:*?\"<>|]"), "_").trim().ifEmpty { "default" }
     }
 
     internal fun saveRecentGames(context: Context, games: List<ScanGame>) {

--- a/app/src/main/java/com/tyranor/next/scanner/GameSaveManager.kt
+++ b/app/src/main/java/com/tyranor/next/scanner/GameSaveManager.kt
@@ -12,7 +12,6 @@ import java.util.Locale
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
-import kotlin.math.abs
 
 class GameSaveManager(private val context: Context) {
     private val appContext = context.applicationContext
@@ -35,7 +34,7 @@ class GameSaveManager(private val context: Context) {
                     val internal = appContext.filesDir
                         ?: return SaveLocation(null, "应用内部存储目录不可用", false)
                     SaveLocation(
-                        File(File(File(internal, "krkr_mirror"), safeSaveName(root)), "savedata"),
+                        File(File(File(internal, "krkr_mirror"), EngineScanner.safeSaveName(root)), "savedata"),
                         "KRKR 独立存档目录",
                         true,
                     )
@@ -60,7 +59,7 @@ class GameSaveManager(private val context: Context) {
                     val external = appContext.getExternalFilesDir(null)
                         ?: return SaveLocation(null, "Tyrano 应用独立存储目录不可用", false)
                     SaveLocation(
-                        File(File(File(external, "save"), "tyrano"), safeSaveName(root)),
+                        File(File(File(external, "save"), "tyrano"), EngineScanner.safeSaveName(root)),
                         "Tyrano 应用独立存档目录",
                         true,
                     )
@@ -130,7 +129,7 @@ class GameSaveManager(private val context: Context) {
         val target = when (game.engine) {
             EngineType.KIRIKIRI -> {
                 val internal = appContext.filesDir ?: return
-                File(File(internal, "krkr_mirror"), safeSaveName(root))
+                File(File(internal, "krkr_mirror"), EngineScanner.safeSaveName(root))
             }
             EngineType.ONS -> {
                 val external = appContext.getExternalFilesDir(null) ?: return
@@ -138,7 +137,7 @@ class GameSaveManager(private val context: Context) {
             }
             EngineType.TYRANO -> {
                 val external = appContext.getExternalFilesDir(null) ?: return
-                File(File(File(external, "save"), "tyrano"), safeSaveName(root))
+                File(File(File(external, "save"), "tyrano"), EngineScanner.safeSaveName(root))
             }
             else -> return
         }
@@ -305,12 +304,6 @@ class GameSaveManager(private val context: Context) {
         val directory = File.createTempFile("save_zip_", "", appContext.cacheDir)
         if (!directory.delete() || !directory.mkdirs()) throw IOException("无法创建临时解压目录")
         return directory
-    }
-
-    private fun safeSaveName(rootPath: String): String {
-        val name = runCatching { File(rootPath).name.takeIf { it.isNotBlank() } }.getOrNull()
-            ?: abs(rootPath.hashCode()).toString()
-        return name.replace(Regex("[\\\\/:*?\"<>|]"), "_").trim().ifEmpty { "default" }
     }
 
     companion object {

--- a/app/src/main/java/com/tyranor/next/scanner/ScanGame.kt
+++ b/app/src/main/java/com/tyranor/next/scanner/ScanGame.kt
@@ -1,5 +1,6 @@
 package com.tyranor.next.scanner
 
+import android.content.Intent
 import android.net.Uri
 
 /** 扫描产出的游戏候选。 */
@@ -22,3 +23,41 @@ data class ScannedRoot(
     val uri: String,
     val name: String,
 )
+
+/** ScanGame ↔ Intent 序列化助手，供各详情页 Activity（引擎设置/存档/在线补丁）复用，避免重复实现。 */
+object ScanGameIntents {
+    private const val EXTRA_TITLE = "extra_title"
+    private const val EXTRA_URI = "extra_uri"
+    private const val EXTRA_ENGINE = "extra_engine"
+    private const val EXTRA_LAUNCH_TARGET = "extra_launch_target"
+    private const val EXTRA_COVER_URI = "extra_cover_uri"
+    private const val EXTRA_VNDB_ID = "extra_vndb_id"
+    private const val EXTRA_METADATA_TITLE = "extra_metadata_title"
+
+    fun putGame(intent: Intent, game: ScanGame): Intent = intent.apply {
+        putExtra(EXTRA_TITLE, game.title)
+        putExtra(EXTRA_URI, game.uri)
+        putExtra(EXTRA_ENGINE, game.engine.name)
+        putExtra(EXTRA_LAUNCH_TARGET, game.launchTarget)
+        game.coverUri?.let { putExtra(EXTRA_COVER_URI, it) }
+        game.vndbId?.let { putExtra(EXTRA_VNDB_ID, it) }
+        game.metadataTitle?.let { putExtra(EXTRA_METADATA_TITLE, it) }
+    }
+
+    fun getGame(intent: Intent): ScanGame? {
+        val title = intent.getStringExtra(EXTRA_TITLE) ?: return null
+        val uri = intent.getStringExtra(EXTRA_URI) ?: return null
+        val engine = runCatching {
+            EngineType.valueOf(intent.getStringExtra(EXTRA_ENGINE).orEmpty())
+        }.getOrDefault(EngineType.UNKNOWN)
+        return ScanGame(
+            title = title,
+            uri = uri,
+            engine = engine,
+            launchTarget = intent.getStringExtra(EXTRA_LAUNCH_TARGET).orEmpty(),
+            coverUri = intent.getStringExtra(EXTRA_COVER_URI),
+            vndbId = intent.getStringExtra(EXTRA_VNDB_ID),
+            metadataTitle = intent.getStringExtra(EXTRA_METADATA_TITLE),
+        )
+    }
+}

--- a/app/src/main/java/com/tyranor/next/ui/common/TimeFormats.kt
+++ b/app/src/main/java/com/tyranor/next/ui/common/TimeFormats.kt
@@ -1,0 +1,24 @@
+package com.tyranor.next.ui.common
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/** 轻量时间格式化助手。 */
+object TimeFormats {
+    /** 完整日期时间：yyyy-MM-dd HH:mm。ts<=0 返回空串。 */
+    fun formatDateTime(timestamp: Long): String {
+        if (timestamp <= 0) return ""
+        return runCatching {
+            SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(Date(timestamp))
+        }.getOrDefault("")
+    }
+
+    /** 日期：yyyy-MM-dd。ts<=0 返回空串。 */
+    fun formatDate(timestamp: Long): String {
+        if (timestamp <= 0) return ""
+        return runCatching {
+            SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date(timestamp))
+        }.getOrDefault("")
+    }
+}

--- a/app/src/main/java/com/tyranor/next/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/main/MainScreen.kt
@@ -14,9 +14,9 @@ import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -57,7 +57,7 @@ fun MainScreen(modifier: Modifier = Modifier) {
   var selectedIndex by rememberSaveable { mutableStateOf(0) }
   val unselectedColor = UnselectedGrey
   // 导航栏样式：应用设置 → 默认 / 圆角液态玻璃（内存态，设置页切换即时生效）
-  remember { AppSettingsStore.initNavStyle(context) }
+  LaunchedEffect(Unit) { AppSettingsStore.initNavStyle(context) }
   val liquidGlass = AppSettingsStore.navStyleState.value == AppSettingsStore.NAV_STYLE_LIQUID_GLASS
 
   // 外层只负责布局：内容区 + 底部导航栏（不用 Scaffold，避免与子页顶部栏的 inset 冲突）

--- a/app/src/main/java/com/tyranor/next/ui/pages/GameScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/pages/GameScreen.kt
@@ -108,6 +108,9 @@ fun GameScreen(modifier: Modifier = Modifier) {
         games = nextGames
         selectedGame = null
         EngineScanner.saveGames(context, nextGames)
+        // 最近记录/快捷启动同步持久化移除，避免切页取消 IO 清理协程后残留脏数据
+        EngineScanner.removeRecentGame(context, target.uri)
+        EngineScanner.removeQuickLaunch(context, target.uri)
         // 仅清理应用内数据（每游戏设置、最近记录、封面缓存、应用内存档镜像）；不触碰游戏文件
         scope.launch(Dispatchers.IO) {
             cleanupDeletedGame(context, target)

--- a/app/src/main/java/com/tyranor/next/ui/pages/HomeScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/pages/HomeScreen.kt
@@ -81,6 +81,9 @@ fun HomeScreen(modifier: Modifier = Modifier) {
         selectedGame = null
         // 从持久游戏库一并移除，避免首页删了但「游戏」页仍显示（复活）
         EngineScanner.removeGame(context, target.uri)
+        // 最近记录/快捷启动同步持久化移除，避免切页取消 IO 清理协程后残留脏数据
+        EngineScanner.removeRecentGame(context, target.uri)
+        EngineScanner.removeQuickLaunch(context, target.uri)
         // 仅清理应用内数据（每游戏设置、最近记录、封面缓存、应用内存档镜像）；不触碰游戏文件
         scope.launch(Dispatchers.IO) {
             cleanupDeletedGame(context, target)

--- a/app/src/main/java/com/tyranor/next/ui/pages/HomeScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/pages/HomeScreen.kt
@@ -45,11 +45,9 @@ import com.tyranor.next.R
 import com.tyranor.next.scanner.EngineScanner
 import com.tyranor.next.scanner.ScanGame
 import com.tyranor.next.theme.NavWhite
+import com.tyranor.next.ui.common.TimeFormats
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 
 @Composable
 fun HomeScreen(modifier: Modifier = Modifier) {
@@ -254,17 +252,10 @@ private fun RecentGameRow(game: ScanGame, onClick: () -> Unit, onLongClick: () -
             modifier = Modifier.weight(1f).padding(start = 14.dp),
         )
         Text(
-            formatOpenTime(game.openTime),
+            TimeFormats.formatDateTime(game.openTime),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(start = 12.dp),
         )
     }
-}
-
-private fun formatOpenTime(ts: Long): String {
-    if (ts <= 0) return ""
-    return runCatching {
-        SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(Date(ts))
-    }.getOrDefault("")
 }

--- a/app/src/main/java/com/tyranor/next/ui/pages/KrkrOnlinePatchActivity.kt
+++ b/app/src/main/java/com/tyranor/next/ui/pages/KrkrOnlinePatchActivity.kt
@@ -60,13 +60,11 @@ import com.tyranor.next.scanner.ScanGame
 import com.tyranor.next.scanner.ScanGameIntents
 import com.tyranor.next.theme.NavWhite
 import com.tyranor.next.theme.TyranorNextTheme
+import com.tyranor.next.ui.common.TimeFormats
 import com.tyranor.next.ui.common.TopBarIcon
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 
 class KrkrOnlinePatchActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -268,7 +266,7 @@ private fun PatchEntryCard(
                 overflow = TextOverflow.Ellipsis,
             )
             Text(
-                listOf(entry.brand, formatPatchDate(entry.timestamp)).filter { it.isNotBlank() }.joinToString(" · "),
+                listOf(entry.brand, TimeFormats.formatDate(entry.timestamp)).filter { it.isNotBlank() }.joinToString(" · "),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,
@@ -321,9 +319,4 @@ private fun PatchEntryCard(
             }
         }
     }
-}
-
-private fun formatPatchDate(timestamp: Long): String {
-    if (timestamp <= 0L) return ""
-    return SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date(timestamp))
 }

--- a/app/src/main/java/com/tyranor/next/ui/pages/KrkrOnlinePatchActivity.kt
+++ b/app/src/main/java/com/tyranor/next/ui/pages/KrkrOnlinePatchActivity.kt
@@ -54,10 +54,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.tyranor.next.R
-import com.tyranor.next.scanner.EngineType
 import com.tyranor.next.scanner.KrkrOnlinePatchService
 import com.tyranor.next.scanner.KrkrPatchEntry
 import com.tyranor.next.scanner.ScanGame
+import com.tyranor.next.scanner.ScanGameIntents
 import com.tyranor.next.theme.NavWhite
 import com.tyranor.next.theme.TyranorNextTheme
 import com.tyranor.next.ui.common.TopBarIcon
@@ -76,10 +76,6 @@ class KrkrOnlinePatchActivity : ComponentActivity() {
             statusBarStyle = androidx.activity.SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT),
             navigationBarStyle = androidx.activity.SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT),
         )
-        @Suppress("DEPRECATION")
-        window.statusBarColor = Color.TRANSPARENT
-        @Suppress("DEPRECATION")
-        window.navigationBarColor = Color.TRANSPARENT
 
         val game = intent.readScanGame()
         if (game == null) {
@@ -103,42 +99,10 @@ class KrkrOnlinePatchActivity : ComponentActivity() {
     }
 
     companion object {
-        private const val EXTRA_TITLE = "extra_title"
-        private const val EXTRA_URI = "extra_uri"
-        private const val EXTRA_ENGINE = "extra_engine"
-        private const val EXTRA_LAUNCH_TARGET = "extra_launch_target"
-        private const val EXTRA_COVER_URI = "extra_cover_uri"
-        private const val EXTRA_VNDB_ID = "extra_vndb_id"
-        private const val EXTRA_METADATA_TITLE = "extra_metadata_title"
+        fun createIntent(context: Context, game: ScanGame): Intent =
+            ScanGameIntents.putGame(Intent(context, KrkrOnlinePatchActivity::class.java), game)
 
-        fun createIntent(context: Context, game: ScanGame): Intent {
-            return Intent(context, KrkrOnlinePatchActivity::class.java).apply {
-                putExtra(EXTRA_TITLE, game.title)
-                putExtra(EXTRA_URI, game.uri)
-                putExtra(EXTRA_ENGINE, game.engine.name)
-                putExtra(EXTRA_LAUNCH_TARGET, game.launchTarget)
-                game.coverUri?.let { putExtra(EXTRA_COVER_URI, it) }
-                game.vndbId?.let { putExtra(EXTRA_VNDB_ID, it) }
-                game.metadataTitle?.let { putExtra(EXTRA_METADATA_TITLE, it) }
-            }
-        }
-
-        private fun Intent.readScanGame(): ScanGame? {
-            val title = getStringExtra(EXTRA_TITLE) ?: return null
-            val uri = getStringExtra(EXTRA_URI) ?: return null
-            val engine = runCatching {
-                EngineType.valueOf(getStringExtra(EXTRA_ENGINE).orEmpty())
-            }.getOrDefault(EngineType.UNKNOWN)
-            return ScanGame(
-                title = title,
-                uri = uri,
-                engine = engine,
-                launchTarget = getStringExtra(EXTRA_LAUNCH_TARGET).orEmpty(),
-                coverUri = getStringExtra(EXTRA_COVER_URI),
-                vndbId = getStringExtra(EXTRA_VNDB_ID),
-                metadataTitle = getStringExtra(EXTRA_METADATA_TITLE),
-            )
-        }
+        private fun Intent.readScanGame(): ScanGame? = ScanGameIntents.getGame(this)
     }
 }
 

--- a/app/src/main/java/com/tyranor/next/ui/pages/PerGameSettingsActivity.kt
+++ b/app/src/main/java/com/tyranor/next/ui/pages/PerGameSettingsActivity.kt
@@ -11,8 +11,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
-import com.tyranor.next.scanner.EngineType
 import com.tyranor.next.scanner.ScanGame
+import com.tyranor.next.scanner.ScanGameIntents
 import com.tyranor.next.theme.TyranorNextTheme
 
 class PerGameSettingsActivity : ComponentActivity() {
@@ -50,42 +50,9 @@ class PerGameSettingsActivity : ComponentActivity() {
     }
 
     companion object {
-        private const val EXTRA_TITLE = "extra_title"
-        private const val EXTRA_URI = "extra_uri"
-        private const val EXTRA_ENGINE = "extra_engine"
-        private const val EXTRA_LAUNCH_TARGET = "extra_launch_target"
-        private const val EXTRA_COVER_URI = "extra_cover_uri"
-        private const val EXTRA_VNDB_ID = "extra_vndb_id"
-        private const val EXTRA_METADATA_TITLE = "extra_metadata_title"
+        fun createIntent(context: Context, game: ScanGame): Intent =
+            ScanGameIntents.putGame(Intent(context, PerGameSettingsActivity::class.java), game)
 
-        fun createIntent(context: Context, game: ScanGame): Intent {
-            return Intent(context, PerGameSettingsActivity::class.java).apply {
-                putExtra(EXTRA_TITLE, game.title)
-                putExtra(EXTRA_URI, game.uri)
-                putExtra(EXTRA_ENGINE, game.engine.name)
-                putExtra(EXTRA_LAUNCH_TARGET, game.launchTarget)
-                game.coverUri?.let { putExtra(EXTRA_COVER_URI, it) }
-                game.vndbId?.let { putExtra(EXTRA_VNDB_ID, it) }
-                game.metadataTitle?.let { putExtra(EXTRA_METADATA_TITLE, it) }
-            }
-        }
-
-        private fun Intent.readScanGame(): ScanGame? {
-            val title = getStringExtra(EXTRA_TITLE) ?: return null
-            val uri = getStringExtra(EXTRA_URI) ?: return null
-            val engineName = getStringExtra(EXTRA_ENGINE).orEmpty()
-            val engine = runCatching { EngineType.valueOf(engineName) }.getOrDefault(EngineType.UNKNOWN)
-            val launchTarget = getStringExtra(EXTRA_LAUNCH_TARGET).orEmpty()
-
-            return ScanGame(
-                title = title,
-                uri = uri,
-                engine = engine,
-                launchTarget = launchTarget,
-                coverUri = getStringExtra(EXTRA_COVER_URI),
-                vndbId = getStringExtra(EXTRA_VNDB_ID),
-                metadataTitle = getStringExtra(EXTRA_METADATA_TITLE),
-            )
-        }
+        private fun Intent.readScanGame(): ScanGame? = ScanGameIntents.getGame(this)
     }
 }

--- a/app/src/main/java/com/tyranor/next/ui/pages/SaveManagementActivity.kt
+++ b/app/src/main/java/com/tyranor/next/ui/pages/SaveManagementActivity.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -46,12 +47,11 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.tyranor.next.scanner.EngineType
 import com.tyranor.next.scanner.GameSaveManager
 import com.tyranor.next.scanner.ScanGame
+import com.tyranor.next.scanner.ScanGameIntents
 import com.tyranor.next.theme.NavWhite
 import com.tyranor.next.theme.TyranorNextTheme
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -64,10 +64,6 @@ class SaveManagementActivity : ComponentActivity() {
             statusBarStyle = androidx.activity.SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT),
             navigationBarStyle = androidx.activity.SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT),
         )
-        @Suppress("DEPRECATION")
-        window.statusBarColor = Color.TRANSPARENT
-        @Suppress("DEPRECATION")
-        window.navigationBarColor = Color.TRANSPARENT
 
         val game = intent.readScanGame()
         if (game == null) {
@@ -91,48 +87,17 @@ class SaveManagementActivity : ComponentActivity() {
     }
 
     companion object {
-        private const val EXTRA_TITLE = "extra_title"
-        private const val EXTRA_URI = "extra_uri"
-        private const val EXTRA_ENGINE = "extra_engine"
-        private const val EXTRA_LAUNCH_TARGET = "extra_launch_target"
-        private const val EXTRA_COVER_URI = "extra_cover_uri"
-        private const val EXTRA_VNDB_ID = "extra_vndb_id"
-        private const val EXTRA_METADATA_TITLE = "extra_metadata_title"
+        fun createIntent(context: Context, game: ScanGame): Intent =
+            ScanGameIntents.putGame(Intent(context, SaveManagementActivity::class.java), game)
 
-        fun createIntent(context: Context, game: ScanGame): Intent {
-            return Intent(context, SaveManagementActivity::class.java).apply {
-                putExtra(EXTRA_TITLE, game.title)
-                putExtra(EXTRA_URI, game.uri)
-                putExtra(EXTRA_ENGINE, game.engine.name)
-                putExtra(EXTRA_LAUNCH_TARGET, game.launchTarget)
-                game.coverUri?.let { putExtra(EXTRA_COVER_URI, it) }
-                game.vndbId?.let { putExtra(EXTRA_VNDB_ID, it) }
-                game.metadataTitle?.let { putExtra(EXTRA_METADATA_TITLE, it) }
-            }
-        }
-
-        private fun Intent.readScanGame(): ScanGame? {
-            val title = getStringExtra(EXTRA_TITLE) ?: return null
-            val uri = getStringExtra(EXTRA_URI) ?: return null
-            val engine = runCatching {
-                EngineType.valueOf(getStringExtra(EXTRA_ENGINE).orEmpty())
-            }.getOrDefault(EngineType.UNKNOWN)
-            return ScanGame(
-                title = title,
-                uri = uri,
-                engine = engine,
-                launchTarget = getStringExtra(EXTRA_LAUNCH_TARGET).orEmpty(),
-                coverUri = getStringExtra(EXTRA_COVER_URI),
-                vndbId = getStringExtra(EXTRA_VNDB_ID),
-                metadataTitle = getStringExtra(EXTRA_METADATA_TITLE),
-            )
-        }
+        private fun Intent.readScanGame(): ScanGame? = ScanGameIntents.getGame(this)
     }
 }
 
 @Composable
 private fun SaveManagementScreen(game: ScanGame) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     val manager = remember { GameSaveManager(context) }
     var location by remember { mutableStateOf(manager.resolveSaveLocation(game)) }
     var fileCount by remember { mutableStateOf(manager.listSaveFiles(game).size) }
@@ -144,7 +109,7 @@ private fun SaveManagementScreen(game: ScanGame) {
     }
 
     fun runSaveTask(block: suspend () -> String) {
-        CoroutineScope(Dispatchers.Main).launch {
+        scope.launch {
             val message = withContext(Dispatchers.IO) {
                 runCatching { block() }.getOrElse { it.message ?: "操作失败" }
             }


### PR DESCRIPTION
## 修复
- **`SaveManagementActivity.runSaveTask`**：改用 `rememberCoroutineScope`，随 Activity 销毁取消（原来裸 `CoroutineScope(Main)` 会在销毁后继续跑）。
- **删除游戏**（首页/游戏页）：最近记录与快捷启动的持久化移除改为同步执行，避免切页取消 IO 清理协程后重启残留脏数据。
- 移除 `SaveManagementActivity` / `KrkrOnlinePatchActivity` 冗余的已弃用 `window.statusBarColor`（`enableEdgeToEdge` 已处理）。
- **ONS `--sharpness` 值校验**：与引擎侧 `OnsSettings.safeSharpness` 一致（0.1~10，否则回退 "2"）。
- **`MainScreen` lint error**：`remember { initNavStyle() }` 返回 Unit → 改 `LaunchedEffect(Unit)`。

## 重构（行为等价）
- 抽取 **`ScanGameIntents`**（ScanGame↔Intent），`PerGameSettings` / `SaveManagement` / `KrkrOnlinePatch` 三处重复的 EXTRA 常量与读写统一。
- **`safeSaveName` 去重** 到 `EngineScanner`。
- **`TimeFormats`**（`formatDateTime`/`formatDate`），`HomeScreen` / `KrkrOnlinePatchActivity` 复用。
- **`EngineScanner` 列表存取去重**：`saveGames`/`saveRecentGames`/`saveQuickLaunch` 与对应 load 共用 `saveList`/`loadList`。

## 验证
`./gradlew assembleDebug` 通过、无编译告警；app 模块 lint 仅剩样式类提示（UseKtx/图标/依赖版本），无 error。