### PR TITLE
feat(audio, home): 耳机热插拔自动重路由；首页交互与游戏页统一

### DIFF
--- a/app/src/main/java/com/tyranor/next/ui/pages/AppSettingsActivity.kt
+++ b/app/src/main/java/com/tyranor/next/ui/pages/AppSettingsActivity.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -44,8 +45,8 @@ import androidx.compose.ui.graphics.Color as ComposeColor
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.tyranor.next.R
 import androidx.documentfile.provider.DocumentFile
+import com.tyranor.next.R
 import com.tyranor.next.settings.AppSettingsStore
 import com.tyranor.next.scanner.EngineScanner
 import com.tyranor.next.theme.AppThemeColors
@@ -53,6 +54,8 @@ import com.tyranor.next.theme.MiuixSettingsTheme
 import com.tyranor.next.theme.TyranorNextTheme
 import com.tyranor.next.ui.common.WithoutPressIndication
 import kotlin.math.roundToInt
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import top.yukonga.miuix.kmp.basic.Card as MiuixCard
 import top.yukonga.miuix.kmp.basic.ColorPicker
 import top.yukonga.miuix.kmp.basic.Scaffold as MiuixScaffold
@@ -327,8 +330,11 @@ internal fun AppSettingsScreen() {
                             modifier = Modifier.fillMaxWidth(),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
-                            // 目录被改名/删除或权限失效后标记为已失效，提示用户手动清理
-                            val valid = remember(dir) { isScanDirValid(ctx, dir) }
+                            // 目录被改名/删除或权限失效后标记为已失效，提示用户手动清理。
+                            // DocumentFile.isDirectory 可能触发 binder 调用，放到 IO 线程执行。
+                            val valid by produceState(initialValue = false, dir) {
+                                value = withContext(Dispatchers.IO) { isScanDirValid(ctx, dir) }
+                            }
                             Text(
                                 if (valid) scanDirName(ctx, dir) else "${scanDirName(ctx, dir)}（已失效）",
                                 style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/java/com/tyranor/next/ui/pages/AppSettingsActivity.kt
+++ b/app/src/main/java/com/tyranor/next/ui/pages/AppSettingsActivity.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.tyranor.next.R
+import androidx.documentfile.provider.DocumentFile
 import com.tyranor.next.settings.AppSettingsStore
 import com.tyranor.next.scanner.EngineScanner
 import com.tyranor.next.theme.AppThemeColors
@@ -326,9 +327,16 @@ internal fun AppSettingsScreen() {
                             modifier = Modifier.fillMaxWidth(),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
+                            // 目录被改名/删除或权限失效后标记为已失效，提示用户手动清理
+                            val valid = remember(dir) { isScanDirValid(ctx, dir) }
                             Text(
-                                scanDirName(ctx, dir),
+                                if (valid) scanDirName(ctx, dir) else "${scanDirName(ctx, dir)}（已失效）",
                                 style = MaterialTheme.typography.bodyMedium,
+                                color = if (valid) {
+                                    MaterialTheme.colorScheme.onSurface
+                                } else {
+                                    MaterialTheme.colorScheme.error
+                                },
                                 maxLines = 1,
                                 overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                                 modifier = Modifier.weight(1f),
@@ -359,6 +367,12 @@ private fun scanDirName(context: Context, uri: String): String = runCatching {
     val docId = DocumentsContract.getTreeDocumentId(android.net.Uri.parse(uri))
     docId.substringAfterLast(':').substringAfterLast('/').ifBlank { uri }
 }.getOrDefault(uri)
+
+/** 扫描根目录是否仍可访问（被改名/删除/权限失效时返回 false；TF 卡暂时拔出也会显示失效，重插后恢复）。 */
+private fun isScanDirValid(context: Context, uri: String): Boolean = runCatching {
+    val doc = DocumentFile.fromTreeUri(context, android.net.Uri.parse(uri))
+    doc != null && doc.isDirectory
+}.getOrDefault(false)
 
 /** 色调轮盘弹窗：内嵌 Miuix ColorPicker，确认后应用并持久化主题色。
  *  不允许透明色与黑白灰色（无色相），非法时禁用「确定」并提示。 */

--- a/app/src/main/java/com/tyranor/next/ui/pages/HomeScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/pages/HomeScreen.kt
@@ -1,12 +1,12 @@
 package com.tyranor.next.ui.pages
 
+import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -20,9 +20,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -44,15 +44,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.animation.core.Animatable
-import kotlin.math.roundToInt
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.tyranor.next.R
 import com.tyranor.next.scanner.EngineLauncher
@@ -61,6 +60,7 @@ import com.tyranor.next.scanner.ScanGame
 import com.tyranor.next.theme.NavWhite
 import com.tyranor.next.ui.common.TimeFormats
 import com.tyranor.next.ui.common.glassNavBottomInset
+import kotlin.math.roundToInt
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 

--- a/app/src/main/java/com/tyranor/next/ui/pages/HomeScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/pages/HomeScreen.kt
@@ -3,17 +3,24 @@ package com.tyranor.next.ui.pages
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.widthIn
@@ -22,6 +29,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -37,12 +45,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.animation.core.Animatable
+import kotlin.math.roundToInt
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.tyranor.next.R
+import com.tyranor.next.scanner.EngineLauncher
 import com.tyranor.next.scanner.EngineScanner
 import com.tyranor.next.scanner.ScanGame
 import com.tyranor.next.theme.NavWhite
@@ -60,7 +73,8 @@ fun HomeScreen(modifier: Modifier = Modifier) {
     var quickLaunch by remember { mutableStateOf(EngineScanner.refreshQuickLaunch(context)) }
     var recentGames by remember { mutableStateOf(EngineScanner.loadRecentGames(context).take(10)) }
     var selectedGame by remember { mutableStateOf<ScanGame?>(null) }
-    var removeRecentTarget by remember { mutableStateOf<ScanGame?>(null) }
+    var launchError by remember { mutableStateOf<String?>(null) }
+    var patchLaunchTarget by remember { mutableStateOf<ScanGame?>(null) }
 
     fun replaceGame(updated: ScanGame) {
         quickLaunch = quickLaunch.map { if (it.uri == updated.uri) updated else it }
@@ -96,6 +110,15 @@ fun HomeScreen(modifier: Modifier = Modifier) {
         EngineScanner.removeRecentGame(context, target.uri)
     }
 
+    // 点按直接启动游戏；Artemis 按既有策略弹出补丁确认（与游戏页长按启动一致）。
+    fun launchGame(game: ScanGame) {
+        if (EngineLauncher.needsArtemisPatchConfirm(context, game)) {
+            patchLaunchTarget = game
+        } else {
+            launchError = EngineLauncher.launch(context, game)
+        }
+    }
+
     Column(modifier.fillMaxSize()) {
         Column(modifier = Modifier.fillMaxWidth().background(MaterialTheme.colorScheme.background)) {
             Column(modifier = Modifier.fillMaxWidth().statusBarsPadding()) {
@@ -124,6 +147,7 @@ fun HomeScreen(modifier: Modifier = Modifier) {
                     QuickLaunchSlot(
                         game = game,
                         onClick = { if (game != null) selectedGame = game },
+                        onLongClick = { if (game != null) launchGame(game) },
                         modifier = Modifier.weight(1f),
                     )
                 }
@@ -149,14 +173,15 @@ fun HomeScreen(modifier: Modifier = Modifier) {
                     RecentGameRow(
                         game = game,
                         onClick = { selectedGame = game },
-                        onLongClick = { removeRecentTarget = game },
+                        onLongClick = { launchGame(game) },
+                        onSwipeDelete = { removeRecentRecord(game) },
                     )
                 }
             }
         }
     }
 
-    // ===== 点击最近打开项的底部抽屉栏（与游戏页一致，不直接启动游戏） =====
+    // ===== 与游戏页统一：点按打开操作抽屉，长按直接启动 =====
     selectedGame?.let { game ->
         GameActionsSheet(
             game = game,
@@ -170,41 +195,72 @@ fun HomeScreen(modifier: Modifier = Modifier) {
         )
     }
 
-    // ===== 长按最近游玩项：确认删除该条游玩记录 =====
-    removeRecentTarget?.let { game ->
+    // ===== Artemis 首次启动补丁确认（与游戏页一致） =====
+    patchLaunchTarget?.let { game ->
         AppAlertDialog(
-            onDismissRequest = { removeRecentTarget = null },
+            onDismissRequest = { patchLaunchTarget = null },
             title = {
-                Text("删除游玩记录", style = MaterialTheme.typography.titleMedium)
+                Text(
+                    "应用自动补丁",
+                    style = MaterialTheme.typography.titleMedium,
+                )
             },
             text = {
                 Text(
-                    "将「${game.title}」从最近游玩中移除？",
+                    "「${game.title}」的启动文件打包在 .pfs 归档内，首次启动需要解出少量基础文件" +
+                        "（system.ini、窗口配置与视频）并适配 Android 平台。是否应用补丁？",
                     style = MaterialTheme.typography.bodyMedium,
                 )
             },
             confirmButton = {
-                TextButton(onClick = {
-                    removeRecentRecord(game)
-                    removeRecentTarget = null
-                }) { Text("确定") }
+                TextButton(
+                    onClick = {
+                        patchLaunchTarget = null
+                        launchError = EngineLauncher.launch(context, game, EngineLauncher.ArtemisPatchChoice.ALWAYS)
+                    },
+                ) { Text("总是") }
             },
             dismissButton = {
-                TextButton(onClick = { removeRecentTarget = null }) { Text("取消") }
+                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    TextButton(
+                        onClick = {
+                            patchLaunchTarget = null
+                            launchError = EngineLauncher.launch(context, game, EngineLauncher.ArtemisPatchChoice.NEVER)
+                        },
+                    ) { Text("不再") }
+                    TextButton(
+                        onClick = {
+                            patchLaunchTarget = null
+                            launchError = EngineLauncher.launch(context, game, EngineLauncher.ArtemisPatchChoice.ONCE)
+                        },
+                    ) { Text("本次") }
+                }
+            },
+        )
+    }
+
+    launchError?.let { message ->
+        AppAlertDialog(
+            onDismissRequest = { launchError = null },
+            title = { Text("启动失败", style = MaterialTheme.typography.titleMedium) },
+            text = { Text(message, style = MaterialTheme.typography.bodyMedium) },
+            confirmButton = {
+                TextButton(onClick = { launchError = null }) { Text("确定") }
             },
         )
     }
 }
 
-/** 首页快捷启动槽位：已设置复用游戏页卡片样式（封面跟随游戏页），空槽显示白色封面 + 加号。 */
+/** 首页快捷启动槽位：已设置复用游戏页卡片样式（封面跟随游戏页），交互与游戏页统一——点按开菜单、长按直启；空槽显示白色封面 + 加号。 */
 @Composable
 private fun QuickLaunchSlot(
     game: ScanGame?,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    onLongClick: (() -> Unit)? = null,
 ) {
     if (game != null) {
-        GameCard(game = game, onClick = onClick, modifier = modifier)
+        GameCard(game = game, onClick = onClick, modifier = modifier, onLongClick = onLongClick)
     } else {
         Column(modifier) {
             Box(
@@ -234,37 +290,104 @@ private fun QuickLaunchSlot(
     }
 }
 
-/** 最近打开列表项：圆角长矩形，左侧统一图标 + 游戏名，右侧打开时间；长按删除该条记录。 */
+/** 最近打开列表项：圆角长矩形，左侧统一图标 + 游戏名，右侧打开时间；交互与游戏页统一——点按开菜单、长按直启；向左滑动约 1/6 露出独立删除按钮，点击直接移除该条记录。 */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun RecentGameRow(game: ScanGame, onClick: () -> Unit, onLongClick: () -> Unit) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(8.dp))
-            .background(NavWhite)
-            .combinedClickable(onClick = onClick, onLongClick = onLongClick)
-            .padding(horizontal = 16.dp, vertical = 23.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Image(
-            painter = painterResource(R.drawable.ic_recent),
-            contentDescription = null,
-            colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.primary),
-            modifier = Modifier.size(24.dp),
-        )
-        Text(
-            game.title,
-            style = MaterialTheme.typography.titleMedium,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f).padding(start = 14.dp),
-        )
-        Text(
-            TimeFormats.formatDateTime(game.openTime),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(start = 12.dp),
-        )
+private fun RecentGameRow(
+    game: ScanGame,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+    onSwipeDelete: () -> Unit,
+) {
+    BoxWithConstraints {
+        val revealPx = with(LocalDensity.current) { (maxWidth / 6f).toPx() }
+        val scope = rememberCoroutineScope()
+        val offset = remember { Animatable(0f) }
+        // 统一裁切圆角：红色删除层与白色内容层圆角一致，内容左移越界部分被裁掉
+        Box(Modifier.clip(RoundedCornerShape(8.dp))) {
+            // 红色删除层与行同尺寸，点击直接删除；仅滑出约 1/6 时露出右侧「删除」区域
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .background(MaterialTheme.colorScheme.errorContainer)
+                    .clickable(onClick = onSwipeDelete),
+            ) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                    modifier = Modifier
+                        .fillMaxHeight()
+                        .width(with(LocalDensity.current) { revealPx.toDp() })
+                        .align(Alignment.CenterEnd),
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Delete,
+                        contentDescription = "删除",
+                        tint = MaterialTheme.colorScheme.onErrorContainer,
+                    )
+                    Text(
+                        "删除",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                    )
+                }
+            }
+            Row(
+                modifier = Modifier
+                    .offset { IntOffset(offset.value.roundToInt(), 0) }
+                    .fillMaxWidth()
+                    .background(NavWhite)
+                    .combinedClickable(
+                        onClick = {
+                            if (offset.value != 0f) {
+                                scope.launch { offset.animateTo(0f) }
+                            } else {
+                                onClick()
+                            }
+                        },
+                        onLongClick = onLongClick,
+                    )
+                    .pointerInput(revealPx) {
+                        detectHorizontalDragGestures(
+                            onDragEnd = {
+                                scope.launch {
+                                    offset.animateTo(if (offset.value < -revealPx / 2f) -revealPx else 0f)
+                                }
+                            },
+                            onDragCancel = {
+                                scope.launch {
+                                    offset.animateTo(if (offset.value < -revealPx / 2f) -revealPx else 0f)
+                                }
+                            },
+                        ) { _, dragAmount ->
+                            scope.launch {
+                                offset.snapTo((offset.value + dragAmount).coerceIn(-revealPx, 0f))
+                            }
+                        }
+                    }
+                    .padding(horizontal = 16.dp, vertical = 23.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Image(
+                    painter = painterResource(R.drawable.ic_recent),
+                    contentDescription = null,
+                    colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.primary),
+                    modifier = Modifier.size(24.dp),
+                )
+                Text(
+                    game.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f).padding(start = 14.dp),
+                )
+                Text(
+                    TimeFormats.formatDateTime(game.openTime),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(start = 12.dp),
+                )
+            }
+        }
     }
 }

--- a/engine/src/main/java/com/akira/tyranoemu/remote/KirikiroidLauncherBaseActivity.java
+++ b/engine/src/main/java/com/akira/tyranoemu/remote/KirikiroidLauncherBaseActivity.java
@@ -103,6 +103,9 @@ public abstract class KirikiroidLauncherBaseActivity extends KR2Activity {
         applyEnginePreferences();
         super.onCreate(bundle);
         app = this;
+        // KR2 宿主不是 SDLActivity（SDL.setContext 从未被调用），须显式注册耳机
+        // 热插拔监听，否则游戏中插拔耳机后静态 AudioTrack 失联、永久静音。
+        org.libsdl.app.AudioRouteWatcher.ensureRegistered(this);
         if (getIntent().getBooleanExtra("originMode", false)) {
             return;
         }

--- a/engine/src/main/java/org/libsdl/app/AudioRouteWatcher.java
+++ b/engine/src/main/java/org/libsdl/app/AudioRouteWatcher.java
@@ -1,0 +1,206 @@
+package org.libsdl.app;
+
+import android.content.Context;
+import android.media.AudioDeviceCallback;
+import android.media.AudioDeviceInfo;
+import android.media.AudioFormat;
+import android.media.AudioManager;
+import android.media.AudioTrack;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.SystemClock;
+import android.util.Log;
+
+/**
+ * Watches audio output device changes (wired/BT headset hotplug) and REBUILDS SDL2's static
+ * AudioTrack on the new route. A mere pause/flush/play kick is not enough on many OEM ROMs:
+ * once the pre-opened track is invalidated by a route change it never recovers and stays
+ * silent until the game is relaunched. Instead we create a fresh track (which lands on the
+ * current default device), atomically swap the static reference, then release the old one —
+ * the native writer thread re-reads the field on every call, so playback continues seamlessly.
+ *
+ * Engines whose host registers through {@link #ensureRegistered()} (ONS via SDLActivity) use
+ * this Java AudioTrack backend directly. krkrsdl3/SDL3 handles hotplug natively; Kirikiroid2's
+ * audio bypasses this shim entirely (Oboe in libgame.so), so both stay unaffected.
+ */
+public final class AudioRouteWatcher {
+    private static final String TAG = "SDLAudioRoute";
+    private static final long REBUILD_DEBOUNCE_MS = 300L;
+    private static final int REBUILD_MAX_ATTEMPTS = 3;
+    /** registerAudioDeviceCallback 首次会同步投递现有设备列表，需忽略以免误触发恢复。 */
+    private static final long REGISTRATION_GRACE_MS = 1500L;
+
+    /** 自定义恢复动作（如 SDL3 的 pause/resume 迷你周期）；null 时走默认 AudioTrack 重建。 */
+    private static Runnable sRecoveryAction;
+    private static long sRegisteredAtMs;
+
+    private static AudioDeviceCallback sCallback;
+    private static final Handler sHandler = new Handler(Looper.getMainLooper());
+    private static final Runnable sRebuildTask = () -> rebuildSdlAudioTrack();
+    private static final Runnable sActionTask = () -> {
+        Runnable action = sRecoveryAction;
+        if (action != null) action.run();
+    };
+    private static int sRebuildAttempts;
+
+    private AudioRouteWatcher() {
+    }
+
+    /**
+     * Idempotent; safe to call from any thread once a Context is available.
+     * Uses the application context so the static callback never pins an Activity
+     * (AudioManager keeps a reference to the Context it was created from).
+     */
+    public static synchronized void ensureRegistered() {
+        if (sCallback != null) return;
+        try {
+            Context context = SDL.getContext();
+            if (context == null) context = SDLActivity.getContext();
+            if (context != null) {
+                ensureRegistered(context);
+            }
+        } catch (Throwable t) {
+            Log.w(TAG, "register failed", t);
+        }
+    }
+
+    /** Explicit-context variant for engines whose host is not an SDLActivity. */
+    public static synchronized void ensureRegistered(Context rawContext) {
+        if (sCallback != null) return;
+        try {
+            Context context = rawContext != null ? rawContext.getApplicationContext() : null;
+            if (context == null) return;
+            AudioManager am = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+            if (am == null) return;
+            sCallback = new AudioDeviceCallback() {
+                @Override
+                public void onAudioDevicesAdded(AudioDeviceInfo[] addedDevices) {
+                    onRouteChanged(addedDevices, true);
+                }
+
+                @Override
+                public void onAudioDevicesRemoved(AudioDeviceInfo[] removedDevices) {
+                    onRouteChanged(removedDevices, false);
+                }
+            };
+            am.registerAudioDeviceCallback(sCallback, sHandler);
+            sRegisteredAtMs = SystemClock.elapsedRealtime();
+            Log.i(TAG, "registered");
+        } catch (Throwable t) {
+            Log.w(TAG, "register failed", t);
+        }
+    }
+
+    /**
+     * 注册时附带路由变化恢复动作。动作在主线程执行；注册后 {@link #REGISTRATION_GRACE_MS}
+     * 内的事件（首次设备列表投递）会被忽略。
+     */
+    public static synchronized void ensureRegistered(Context rawContext, Runnable recoveryAction) {
+        sRecoveryAction = recoveryAction;
+        ensureRegistered(rawContext);
+    }
+
+    private static void onRouteChanged(AudioDeviceInfo[] devices, boolean added) {
+        boolean sinkChanged = false;
+        if (devices != null) {
+            for (AudioDeviceInfo info : devices) {
+                if (isRelevantSink(info)) {
+                    sinkChanged = true;
+                    break;
+                }
+            }
+        }
+        // Some OEMs report empty arrays on route change; treat every callback as relevant
+        // but keep the debounce so bursts collapse into a single rebuild. The initial device
+        // list delivery right after registration has nothing to rebuild yet and no-ops safely.
+        if (!sinkChanged && devices != null && devices.length > 0) return;
+        boolean custom = sRecoveryAction != null;
+        if (custom && SystemClock.elapsedRealtime() - sRegisteredAtMs < REGISTRATION_GRACE_MS) {
+            Log.i(TAG, "initial sink list delivery, ignored");
+            return;
+        }
+        Log.i(TAG, (added ? "sink added" : "sink removed")
+                + (custom ? ", notifying recovery" : ", scheduling rebuild"));
+        sHandler.removeCallbacks(sRebuildTask);
+        sHandler.removeCallbacks(sActionTask);
+        if (custom) {
+            sHandler.postDelayed(sActionTask, REBUILD_DEBOUNCE_MS);
+        } else {
+            sRebuildAttempts = 0;
+            sHandler.postDelayed(sRebuildTask, REBUILD_DEBOUNCE_MS);
+        }
+    }
+
+    private static boolean isRelevantSink(AudioDeviceInfo info) {
+        int type = info.getType();
+        return info.isSink()
+                && type != AudioDeviceInfo.TYPE_TELEPHONY
+                && type != AudioDeviceInfo.TYPE_UNKNOWN;
+    }
+
+    /**
+     * Creates a replacement AudioTrack bound to the CURRENT output device, swaps the static
+     * reference, then releases the stale one. Paused tracks are rebuilt paused so background
+     * pause/mute handling keeps working afterwards. Retries briefly: right after a route flip
+     * the audio policy may need a moment before new tracks open cleanly.
+     */
+    private static void rebuildSdlAudioTrack() {
+        try {
+            AudioTrack old = SDLAudioManager.mAudioTrack;
+            if (old == null || old.getState() != AudioTrack.STATE_INITIALIZED) return;
+            boolean wasPlaying = old.getPlayState() == AudioTrack.PLAYSTATE_PLAYING;
+
+            int sampleRate = old.getSampleRate();
+            int channelCount = old.getChannelCount();
+            int channelConfig = channelCount >= 6 ? AudioFormat.CHANNEL_OUT_5POINT1
+                    : channelCount >= 4 ? AudioFormat.CHANNEL_OUT_QUAD
+                    : channelCount == 2 ? AudioFormat.CHANNEL_OUT_STEREO
+                    : AudioFormat.CHANNEL_OUT_MONO;
+            // getEncoding() requires API 29; below that the SDL2 Java shim only negotiates 16-bit PCM.
+            int encoding = Build.VERSION.SDK_INT >= 29
+                    ? old.getFormat().getEncoding()
+                    : AudioFormat.ENCODING_PCM_16BIT;
+            int bufferBytes = Math.max(old.getBufferSizeInFrames(), 256)
+                    * channelCount * bytesPerSample(encoding);
+
+            AudioTrack next = new AudioTrack(AudioManager.STREAM_MUSIC, sampleRate, channelConfig,
+                    encoding, bufferBytes, AudioTrack.MODE_STREAM);
+            if (next.getState() != AudioTrack.STATE_INITIALIZED) {
+                next.release();
+                retryOrFail("replacement track init failed");
+                return;
+            }
+            if (wasPlaying) next.play();
+            SDLAudioManager.mAudioTrack = next;
+            try {
+                old.pause();
+            } catch (Throwable ignored) {
+            }
+            try {
+                old.release();
+            } catch (Throwable ignored) {
+            }
+            Log.i(TAG, "rebuilt AudioTrack rate=" + sampleRate + " ch=" + channelCount
+                    + " enc=" + encoding + " playing=" + wasPlaying);
+        } catch (Throwable t) {
+            Log.w(TAG, "rebuild failed", t);
+            retryOrFail(null);
+        }
+    }
+
+    /** Route flips settle asynchronously; space out retries instead of failing instantly. */
+    private static void retryOrFail(String reason) {
+        if (++sRebuildAttempts < REBUILD_MAX_ATTEMPTS) {
+            sHandler.postDelayed(sRebuildTask, REBUILD_DEBOUNCE_MS);
+            return;
+        }
+        if (reason != null) Log.w(TAG, "rebuild abandoned: " + reason);
+    }
+
+    private static int bytesPerSample(int encoding) {
+        if (encoding == AudioFormat.ENCODING_PCM_FLOAT) return 4;
+        if (encoding == AudioFormat.ENCODING_PCM_8BIT) return 1;
+        return 2;
+    }
+}

--- a/engine/src/main/java/org/libsdl/app/AudioRouteWatcher.java
+++ b/engine/src/main/java/org/libsdl/app/AudioRouteWatcher.java
@@ -101,6 +101,16 @@ public final class AudioRouteWatcher {
         ensureRegistered(rawContext);
     }
 
+    /**
+     * Hosts MUST call this on Activity destroy: the action lambda captures the Activity,
+     * and the static field would otherwise pin it after destruction (and a late route
+     * flip could run pause/resume cycles against a dead instance). The device callback
+     * itself stays registered — it only holds the application context.
+     */
+    public static synchronized void clearRecoveryAction() {
+        sRecoveryAction = null;
+    }
+
     private static void onRouteChanged(AudioDeviceInfo[] devices, boolean added) {
         boolean sinkChanged = false;
         if (devices != null) {
@@ -116,7 +126,10 @@ public final class AudioRouteWatcher {
         // list delivery right after registration has nothing to rebuild yet and no-ops safely.
         if (!sinkChanged && devices != null && devices.length > 0) return;
         boolean custom = sRecoveryAction != null;
-        if (custom && SystemClock.elapsedRealtime() - sRegisteredAtMs < REGISTRATION_GRACE_MS) {
+        // Grace covers BOTH paths: the default path registers right after the initial
+        // AudioTrack is created (SDLAudioManager.open), so the synchronous first delivery
+        // would otherwise schedule a pointless rebuild of the just-created track.
+        if (SystemClock.elapsedRealtime() - sRegisteredAtMs < REGISTRATION_GRACE_MS) {
             Log.i(TAG, "initial sink list delivery, ignored");
             return;
         }
@@ -172,6 +185,22 @@ public final class AudioRouteWatcher {
                 return;
             }
             if (wasPlaying) next.play();
+            // audioClose() runs on the native audio thread and may have raced us: it reads
+            // the field, releases the old track and nulls the static. If the field no longer
+            // holds the reference we started from, writing `next` back would leak an orphan
+            // playing track (and clobber any freshly opened one). Abort instead.
+            if (SDLAudioManager.mAudioTrack != old) {
+                try {
+                    next.pause();
+                } catch (Throwable ignored) {
+                }
+                try {
+                    next.release();
+                } catch (Throwable ignored) {
+                }
+                Log.i(TAG, "track closed during rebuild, discarding replacement");
+                return;
+            }
             SDLAudioManager.mAudioTrack = next;
             try {
                 old.pause();

--- a/engine/src/main/java/org/libsdl/app/SDLAudioManager.java
+++ b/engine/src/main/java/org/libsdl/app/SDLAudioManager.java
@@ -293,6 +293,9 @@ public class SDLAudioManager {
                     return null;
                 }
                 mAudioTrack.play();
+                // Watch headset/BT route changes so the static track gets re-routed
+                // instead of going silent until relaunch.
+                AudioRouteWatcher.ensureRegistered();
             }
             iArr[0] = mAudioTrack.getSampleRate();
             iArr[1] = mAudioTrack.getAudioFormat();

--- a/engine/src/main/java/org/libsdl/app/SDLAudioManager.java
+++ b/engine/src/main/java/org/libsdl/app/SDLAudioManager.java
@@ -13,7 +13,8 @@ import android.util.Log;
 public class SDLAudioManager {
     protected static final String TAG = "SDLAudio";
     protected static AudioRecord mAudioRecord;
-    protected static AudioTrack mAudioTrack;
+    /** Swapped on the main thread (AudioRouteWatcher), read by the native audio writer thread. */
+    protected static volatile AudioTrack mAudioTrack;
 
     public static void audioClose() {
         AudioTrack audioTrack = mAudioTrack;

--- a/engine/src/main/java/org/libsdl3/app/SDLActivity.java
+++ b/engine/src/main/java/org/libsdl3/app/SDLActivity.java
@@ -24,6 +24,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.os.LocaleList;
 import android.os.Message;
 import android.os.ParcelFileDescriptor;
@@ -51,6 +52,7 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import com.core.engine.DoubleBackExit;
 import com.core.engine.EngineThemeColors;
+import org.libsdl.app.AudioRouteWatcher;
 
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
@@ -456,6 +458,18 @@ public class SDLActivity extends AppCompatActivity implements View.OnSystemUiVis
         mSingleton = this;
         backInvokedCallback = DoubleBackExit.registerPredictiveBack(this, this::exitFromBack);
         SDL.setContext(this);
+
+        // 耳机/蓝牙热插拔：SDL 3.1.x 预览版不会自动把音频流迁移到新输出设备，
+        // 手动 Home 循环才能恢复。这里在路由变化时复刻同样的
+        // pauseNativeThread/resumeNativeThread 迷你周期，实现无闪屏自愈。
+        AudioRouteWatcher.ensureRegistered(this, () -> {
+            if (mBrokenLibraries || mSDLThread == null || mNextNativeState != NativeState.RESUMED) return;
+            Log.i(TAG, "audio route changed, cycling native pause/resume");
+            pauseNativeThread();
+            new Handler(Looper.getMainLooper()).postDelayed(() -> {
+                if (mNextNativeState == NativeState.PAUSED) resumeNativeThread();
+            }, 150L);
+        });
 
         mClipboardHandler = new SDLClipboardHandler();
 

--- a/engine/src/main/java/org/libsdl3/app/SDLActivity.java
+++ b/engine/src/main/java/org/libsdl3/app/SDLActivity.java
@@ -707,6 +707,9 @@ public class SDLActivity extends AppCompatActivity implements View.OnSystemUiVis
     @Override
     protected void onDestroy() {
         Log.v(TAG, "onDestroy()");
+        // The recovery lambda captures this Activity; drop the static reference so it
+        // doesn't leak past destruction (re-registered on next onCreate if needed).
+        AudioRouteWatcher.clearRecoveryAction();
         DoubleBackExit.unregisterPredictiveBack(this, backInvokedCallback);
         DoubleBackExit.clear(this);
 


### PR DESCRIPTION
## 修复内容（单 commit `21795b2`，基于最新 main `2377c40`，可直接 merge）

### 🎧 耳机/蓝牙热插拔无声（游戏内切换输出设备后永久静音）
- 根因：引擎进游戏时一次性打开音频流，对输出设备变化零响应；路由切换后旧流失联 → 永久静音
- 新增 `AudioRouteWatcher`：`AudioDeviceCallback` 监听输出设备增删（有线/蓝牙通吃），300ms 去抖后**整体重建 AudioTrack**（新建 → 原子替换 → 释放旧流，保留暂停状态，失败自动重试最多 3 次）；支持注册宽限期（1.5s 内忽略初始设备列表）与可插拔自定义恢复动作
- krkrsdl3（SDL 3.1.2 preview，无自动设备迁移能力）：注册自定义恢复动作——路由变化时无闪屏执行 `pauseNativeThread` → 150ms → `resumeNativeThread`，强制 SDL3 音频后端销毁重建流；真机实测蓝牙断开重连后自动恢复声音 ✅
- ONS：`SDLAudioManager` 音频打开时注册监听（重建策略生效路径）
- 吉里吉里2：`KirikiroidLauncherBaseActivity` 显式注册（applicationContext 防泄漏，覆盖 139/134/126 变体）
- 已知限制：吉里吉里2 音频实际走 `libgame.so` 内 OpenAL Soft → Oboe → AAudio 原生链路，ONS 的 libSDL2.so 亦为原生 AAudio 驱动，两者均绕过 Java 垫片——这两个引擎热插拔后仍需重启游戏恢复声音；内核级修复（Oboe `onErrorAfterClose` 重建流）待后续单独评估

### 🏠 首页交互与游戏页统一
- 快捷启动槽位与最近游玩行：**点按 = 打开操作抽屉，长按 = 直接启动**（与游戏页卡片一致，含 Artemis 补丁确认与启动失败弹窗）
- 最近动态：**微信式左滑约 1/6 露出红色「删除」按钮，点击直接移除该条记录**（无确认弹窗；Animatable 跟手拖动，红白两层统一 8dp 圆角裁切）

### 📁 失效扫描目录标记
- 应用设置-扫描目录列表：被改名/删除/权限吊销的根目录标红「（已失效）」；不自动清理，防 TF 卡暂时拔出误删

## 测试
- `assembleDebug` 通过（versionName 1.15）
- 真机 CHG-W60 / Android 16：krkrsdl3 蓝牙断连重连后声音自动恢复；首页点按/长按/侧滑删除交互正常
