### PR TITLE
feat(rpgmaker): add virtual mouse simulation for MV/MZ games (issue #25)

### DIFF
--- a/engine/src/main/assets/__tyranor_mouse.js
+++ b/engine/src/main/assets/__tyranor_mouse.js
@@ -1,0 +1,95 @@
+(function () {
+  "use strict";
+  /* 虚拟鼠标合成事件 API（RPG Maker MV/MZ）。
+   * 坐标为 CSS 像素（clientX/clientY 空间）；事件从命中元素冒泡到
+   * window，被 rmmz_core 的 TouchInput 捕获。MZ 不校验 isTrusted。
+   * button：0=左键，2=右键（RMMZ 右键=取消/呼出菜单）。 */
+  if (window.__tnMouse) return;
+
+  /** 命中测试：边缘内缩 1px，避免光标贴边时 elementFromPoint
+   *  落到 html/body 上导致事件派发不进游戏画布。 */
+  function hitElement(x, y) {
+    var cx = Math.min(Math.max(x, 0), (window.innerWidth || 1) - 1);
+    var cy = Math.min(Math.max(y, 0), (window.innerHeight || 1) - 1);
+    try { return document.elementFromPoint(cx, cy); } catch (e) { return null; }
+  }
+
+  function fire(constructor, init) {
+    var el = hitElement(init.clientX, init.clientY) ||
+      document.body || document.documentElement;
+    if (!el) return;
+    var ev = new constructor(init.type, init);
+    // 关键：MZ 的 TouchInput 读 event.pageX/pageY（rmmz_core _onLeftButtonDown
+    // 等），而 pageX/pageY 不在 MouseEventInit 标准字段里，合成事件上恒为
+    // undefined → Graphics.pageToCanvasX(undefined)=NaN → isInsideCanvas 恒
+    // false → 点击/悬停全部失效。这里在实例上手动补齐（遮蔽原型 getter）。
+    // MZ 页面无滚动，page 坐标 == client 坐标。
+    try {
+      Object.defineProperty(ev, "pageX", { value: init.clientX || 0 });
+      Object.defineProperty(ev, "pageY", { value: init.clientY || 0 });
+    } catch (e) { /* 极端实现下忽略 */ }
+    el.dispatchEvent(ev);
+  }
+
+  function mouseEvent(type, x, y, button) {
+    fire(MouseEvent, {
+      type: type, clientX: x, clientY: y,
+      screenX: x, screenY: y,
+      button: button || 0,
+      buttons: type === "mouseup" ? 0 : (button || 0) === 2 ? 2 : 1,
+      bubbles: true, cancelable: true
+    });
+  }
+
+  window.__tnMouse = {
+    /** 光标移动（驱动 RMMZ 菜单 hover 高亮） */
+    move: function (x, y) { mouseEvent("mousemove", x, y, 0); },
+    down: function (x, y, button) { mouseEvent("mousedown", x, y, button); },
+    up: function (x, y, button) { mouseEvent("mouseup", x, y, button); },
+    /** 左键单击 = down + (按住 ~50ms) + up + click。
+     *  不能同步 down+up：本作的 Window_Message.isTriggered 走
+     *  TouchInput.isRepeated() = isPressed() && (triggered || 长按重复)，
+     *  同帧复位 _mousePressed 会让下一帧 isPressed()=false，对话永不推进
+     *  （真实鼠标靠人手按住数帧才生效）。 */
+    click: function (x, y) {
+      var self = this;
+      this.down(x, y, 0);
+      setTimeout(function () {
+        self.up(x, y, 0);
+        fire(MouseEvent, { type: "click", clientX: x, clientY: y, button: 0, bubbles: true, cancelable: true });
+      }, 50);
+    },
+    /** 右键单击（取消/返回）：mousedown/up button=2 + contextmenu */
+    rclick: function (x, y) {
+      this.down(x, y, 2);
+      this.up(x, y, 2);
+      fire(MouseEvent, {
+        type: "contextmenu", clientX: x, clientY: y,
+        button: 2, buttons: 0, bubbles: true, cancelable: true
+      });
+    },
+    /** 滚轮：deltaMode 固定 0（像素），作用于光标处窗口。
+     *  注意：合成（untrusted）wheel 事件不会触发浏览器原生滚动，
+     *  MZ 的列表由 JS 接管滚动不受影响；但 DOM 滚动容器（如修改器
+     *  面板 .tm-content）需要这里手动补滚，向上找最近可滚祖先。 */
+    wheel: function (deltaY, x, y) {
+      fire(WheelEvent, {
+        type: "wheel", deltaX: 0, deltaY: deltaY, deltaZ: 0, deltaMode: 0,
+        clientX: x, clientY: y, bubbles: true, cancelable: true
+      });
+      var el = hitElement(x, y);
+      var depth = 0;
+      while (el && el !== document.body && el !== document.documentElement && depth++ < 8) {
+        if (el.scrollHeight > el.clientHeight + 1) {
+          var oy = "";
+          try { oy = getComputedStyle(el).overflowY; } catch (e) { oy = ""; }
+          if (oy === "auto" || oy === "scroll" || oy === "overlay") {
+            el.scrollTop += deltaY;
+            return;
+          }
+        }
+        el = el.parentElement;
+      }
+    }
+  };
+})();

--- a/engine/src/main/assets/__tyranor_mouse.js
+++ b/engine/src/main/assets/__tyranor_mouse.js
@@ -31,12 +31,15 @@
     el.dispatchEvent(ev);
   }
 
+  /** 暂停时取消：用于 50ms click timer + 释放按压状态。 */
+  var pendingClick = null;
+
   function mouseEvent(type, x, y, button) {
     fire(MouseEvent, {
       type: type, clientX: x, clientY: y,
       screenX: x, screenY: y,
       button: button || 0,
-      buttons: type === "mouseup" ? 0 : (button || 0) === 2 ? 2 : 1,
+      buttons: type === "mousedown" ? (button === 2 ? 2 : 1) : 0,
       bubbles: true, cancelable: true
     });
   }
@@ -54,7 +57,9 @@
     click: function (x, y) {
       var self = this;
       this.down(x, y, 0);
-      setTimeout(function () {
+      if (pendingClick) { clearTimeout(pendingClick); }
+      pendingClick = setTimeout(function () {
+        pendingClick = null;
         self.up(x, y, 0);
         fire(MouseEvent, { type: "click", clientX: x, clientY: y, button: 0, bubbles: true, cancelable: true });
       }, 50);
@@ -90,6 +95,13 @@
         }
         el = el.parentElement;
       }
+    },
+    /** 暂停/重载时调用：取消未完成的 click timer + 释放 DOM 按压状态。
+     *  VirtualMouseLayer.reset() 在退后台时触发。 */
+    cancel: function () {
+      if (pendingClick) { clearTimeout(pendingClick); pendingClick = null; }
+      this.up(0, 0, 0);
+      this.up(0, 0, 2);
     }
   };
 })();

--- a/engine/src/main/java/com/core/tyrano/TyranoActivity.kt
+++ b/engine/src/main/java/com/core/tyrano/TyranoActivity.kt
@@ -49,6 +49,7 @@ import org.json.JSONObject
  */
 class TyranoActivity : Activity() {
     private var webView: WebView? = null
+    private var virtualMouseLayer: VirtualMouseLayer? = null
     private var gameDir: String? = null
     private var gameRootFile: File? = null
     private var saveDirectory: File? = null
@@ -180,6 +181,15 @@ class TyranoActivity : Activity() {
         }
         webView = browser
         root.addView(browser)
+        // 虚拟鼠标层（issue #25）：仅 RPG Maker MV/MZ 需要，叠在 WebView 之上
+        if (webGameType == WebGameType.RPG_MV || webGameType == WebGameType.RPG_MZ) {
+            val layer = VirtualMouseLayer(this) { js ->
+                webView?.let { v -> runCatching { v.evaluateJavascript(js, null) } }
+            }
+            virtualMouseLayer = layer
+            root.addView(layer, FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT))
+        }
         setContentView(root)
 
         configureWebView(browser)
@@ -207,6 +217,11 @@ class TyranoActivity : Activity() {
     }
 
     private fun loadAsset(name: String): ByteArray = assets.open(name).buffered().use { it.readBytes() }
+
+    /** 虚拟鼠标合成事件 API（懒加载缓存；见 assets/__tyranor_mouse.js）。 */
+    private val mouseJs: String by lazy {
+        runCatching { loadAsset(VIRTUAL_MOUSE_ASSET).toString(Charsets.UTF_8) }.getOrDefault("")
+    }
 
     private fun buildRpgMakerModHtml(): String {
         val colors = EngineThemeColors.fromIntent(intent)
@@ -262,6 +277,10 @@ class TyranoActivity : Activity() {
             override fun onPageFinished(view: WebView?, url: String?) {
                 super.onPageFinished(view, url)
                 Log.i(TAG, "onPageFinished url=$url")
+                // 虚拟鼠标合成事件 API（幂等，页面每次加载后重新注入）
+                if (virtualMouseLayer != null && view != null) {
+                    runCatching { view.evaluateJavascript(mouseJs, null) }
+                }
             }
 
             override fun onReceivedError(
@@ -519,6 +538,7 @@ class TyranoActivity : Activity() {
     }
 
     override fun onPause() {
+        virtualMouseLayer?.reset()
         runCatching { webView?.loadUrl("javascript:if(window._tyrano_player){_tyrano_player.pauseAllAudio();}") }
         runCatching { webView?.onPause() }
         super.onPause()
@@ -841,6 +861,7 @@ class TyranoActivity : Activity() {
         private const val RPG_MAKER_MOD_UI_ASSET = "__rpgmaker_mod_ui.js"
         private const val RPG_MAKER_MOD_CSS_ASSET = "__rpgmaker_mod.css"
         private const val RPG_MAKER_MOD_ICON_ASSET = "__rpgmaker_mod_icon.png"
+        private const val VIRTUAL_MOUSE_ASSET = "__tyranor_mouse.js"
         private const val RPG_MAKER_MOD_CORE_PATH = "__tyranor__/rpgmaker_mod_core.js"
         private const val RPG_MAKER_MOD_UI_PATH = "__tyranor__/rpgmaker_mod_ui.js"
         private const val RPG_MAKER_MOD_CSS_PATH = "__tyranor__/rpgmaker_mod.css"

--- a/engine/src/main/java/com/core/tyrano/VirtualMouseLayer.kt
+++ b/engine/src/main/java/com/core/tyrano/VirtualMouseLayer.kt
@@ -134,7 +134,11 @@ class VirtualMouseLayer(
         state = STATE_IDLE
         pid1 = -1
         pid2 = -1
-        flushNow()
+        // 取消 JS 侧未完成的 click timer + 释放按压状态；跳过 flushNow
+        // 避免退后台后旧 move/wheel 事件在恢复时才派发。
+        js("cancel")
+        pendingCssX = Float.NaN
+        pendingWheelDelta = 0f
         invalidate()
     }
 

--- a/engine/src/main/java/com/core/tyrano/VirtualMouseLayer.kt
+++ b/engine/src/main/java/com/core/tyrano/VirtualMouseLayer.kt
@@ -1,0 +1,400 @@
+package com.core.tyrano
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.RectF
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewConfiguration
+import java.util.Locale
+
+/**
+ * WebView 虚拟鼠标层（RPG Maker MV/MZ 专用，见 issue #25）。
+ *
+ * 手势语义（通用虚拟鼠标范式）：
+ *  - 手柄：可拖动悬浮圆钮，单击切换光标模式，位置持久化。
+ *  - 光标模式：
+ *      单指拖动        → 相对移动光标（Wine 式，hover 跟随）
+ *      单指快速点按    → 左键点击
+ *      双指上下滑动    → 滚轮（作用于光标处窗口）
+ *      单指长按 350ms  → 右键点击
+ *      双指快速点按    → 右键点击
+ *  - 光标关闭时除手柄区域一律放行 WebView（触屏零干扰）。
+ *
+ * 合成事件经 [dispatchJs] 调用注入的 `window.__tnMouse`（坐标为 CSS 像素），
+ * move/wheel 按 ~16ms 批量刷新以降低 IPC 频率。
+ */
+class VirtualMouseLayer(
+    context: Context,
+    private val dispatchJs: (String) -> Unit,
+) : View(context) {
+
+    private companion object {
+        const val LONG_PRESS_MS = 350L
+        const val TWO_FINGER_TAP_MS = 300L
+        const val WHEEL_SENS = 4.0f
+        const val CURSOR_SENS = 1.5f
+        const val FLUSH_INTERVAL_MS = 16L
+        const val HANDLE_RADIUS_DP = 23f
+        const val CURSOR_SCALE_DP = 1.2f
+        const val PREFS = "tyrano_virtual_mouse"
+        const val KEY_HANDLE_X = "handle_nx"
+        const val KEY_HANDLE_Y = "handle_ny"
+
+        // 手势状态机
+        const val STATE_IDLE = 0      // 无手势
+        const val STATE_HANDLE = 1    // 操作手柄
+        const val STATE_PENDING = 2   // 单指按下未超 slop（等长按/点按判定）
+        const val STATE_DRAG = 3      // 单指拖动光标
+        const val STATE_WHEEL = 4     // 双指滚动
+        const val STATE_COOLDOWN = 5  // 多指手势结束后的收尾（忽略剩余手指直至全部抬起）
+        const val STATE_CONSUMED = 6  // 已触发右键，忽略本手势剩余部分
+    }
+
+    private val density = resources.displayMetrics.density
+    private val touchSlop = ViewConfiguration.get(context).scaledTouchSlop
+    private val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+    /** 手柄圆钮半径（px） */
+    private val handleR = HANDLE_RADIUS_DP * density
+
+    // ---- 手柄 / 光标位置（px；光标存归一化值防旋转丢位） ----
+    private var hx = -1f
+    private var hy = -1f
+    private var active = false
+    private var cnx = 0.5f
+    private var cny = 0.4f
+
+    // ---- 手势状态 ----
+    private var state = STATE_IDLE
+    private var pid1 = -1            // 主指（单指手势 / 双指中的第一指）
+    private var pid2 = -1            // 第二指（双指滚动）
+    private var p1x = 0f; private var p1y = 0f
+    private var p2x = 0f; private var p2y = 0f
+    private var lastCx = 0f; private var lastCy = 0f // 双指质心
+    private var sx = 0f; private var sy = 0f
+    private var moved = false
+    private var handleDrag = false
+    private var hox = 0f; private var hoy = 0f
+    private var downAt = 0L
+    private var twoFingerAt = 0L
+
+    // ---- 合成事件批量刷新 ----
+    private var pendingCssX = Float.NaN
+    private var pendingCssY = 0f
+    private var pendingWheelDelta = 0f
+    private var flushPosted = false
+
+    // ---- 画笔 ----
+    private val handleFill = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
+    private val handleStroke = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        strokeWidth = density
+        color = 0x73FFFFFF
+    }
+    private val glyphPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        strokeWidth = 1.8f * density
+        color = Color.WHITE
+        strokeCap = Paint.Cap.ROUND
+    }
+    private val cursorShadow = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
+    private val cursorFill = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
+    private val cursorStroke = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        strokeWidth = density * 0.9f
+        color = 0xE6141414.toInt()
+        strokeJoin = Paint.Join.ROUND
+    }
+    private val cursorPath = Path()
+    private val glyphRect = RectF()
+
+    private val longPressRunnable = Runnable {
+        // 单指长按 = 右键（一次性消费，忽略本手势剩余部分）
+        if (state == STATE_PENDING && !moved) {
+            state = STATE_CONSUMED
+            invalidate()
+            js("rclick", cnx * width / density, cny * height / density)
+        }
+    }
+    private val flushRunnable = Runnable {
+        flushPosted = false
+        flushNow()
+    }
+
+    /** 页面重载 / 退后台时复位手势，但保留光标开关与位置。 */
+    fun reset() {
+        removeCallbacks(longPressRunnable)
+        removeCallbacks(flushRunnable)
+        flushPosted = false
+        state = STATE_IDLE
+        pid1 = -1
+        pid2 = -1
+        flushNow()
+        invalidate()
+    }
+
+    // ============================================================ 绘制
+
+    override fun onSizeChanged(w: Int, h: Int, ow: Int, oh: Int) {
+        super.onSizeChanged(w, h, ow, oh)
+        if (w <= 0 || h <= 0) return
+        if (hx < 0f) {
+            hx = prefs.getFloat(KEY_HANDLE_X, 0.055f) * w
+            hy = prefs.getFloat(KEY_HANDLE_Y, 0.34f) * h
+        }
+        hx = hx.coerceIn(handleR, w - handleR)
+        hy = hy.coerceIn(handleR, h - handleR)
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        drawHandle(canvas)
+        if (active) drawCursor(canvas)
+    }
+
+    private fun drawHandle(canvas: Canvas) {
+        handleFill.color = if (active) 0x73469AFF.toInt() else 0x29FFFFFF
+        canvas.drawCircle(hx, hy, handleR, handleFill)
+        canvas.drawCircle(hx, hy, handleR, handleStroke)
+        // 简笔鼠标轮廓：圆角矩形机身 + 中线 + 左键分界
+        val bw = handleR * 0.78f
+        val bh = handleR * 1.18f
+        glyphRect.set(hx - bw / 2f, hy - bh / 2f, hx + bw / 2f, hy + bh / 2f)
+        canvas.drawRoundRect(glyphRect, bw / 2.6f, bw / 2.6f, glyphPaint)
+        canvas.drawLine(hx, hy - bh / 2f + glyphPaint.strokeWidth, hx, hy - bh * 0.08f, glyphPaint)
+        canvas.drawLine(glyphRect.left, hy - bh * 0.08f, glyphRect.right, hy - bh * 0.08f, glyphPaint)
+    }
+
+    /** 标准指针箭头：竖直左缘 + 内凹缺口 + 甩尾，滚轮态填充黄色。 */
+    private fun drawCursor(canvas: Canvas) {
+        val x = cnx * width
+        val y = cny * height
+        val s = CURSOR_SCALE_DP * density
+        cursorPath.rewind()
+        cursorPath.moveTo(x, y)                 // 尖端
+        cursorPath.lineTo(x, y + 13.6f * s)     // 左缘（竖直）
+        cursorPath.lineTo(x + 3.3f * s, y + 10.6f * s)   // 内凹
+        cursorPath.lineTo(x + 5.6f * s, y + 15.8f * s)   // 尾部外缘
+        cursorPath.lineTo(x + 7.7f * s, y + 14.8f * s)   // 尾部内缘
+        cursorPath.lineTo(x + 5.6f * s, y + 9.9f * s)    // 尾根
+        cursorPath.lineTo(x + 10.3f * s, y + 9.6f * s)   // 右侧倒钩
+        cursorPath.close()
+        canvas.save()
+        canvas.translate(0.9f * density, 1.5f * density)
+        cursorShadow.color = 0x59000000
+        canvas.drawPath(cursorPath, cursorShadow)
+        canvas.restore()
+        cursorFill.color = if (state == STATE_WHEEL) 0xFFFFD34D.toInt() else Color.WHITE
+        canvas.drawPath(cursorPath, cursorFill)
+        canvas.drawPath(cursorPath, cursorStroke)
+    }
+
+    // ============================================================ 触控
+
+    @SuppressLint("ClickableViewAccessibility")
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                if (pid1 != -1) return false
+                pid1 = event.getPointerId(0)
+                p1x = event.x; sx = event.x
+                p1y = event.y; sy = event.y
+                lastCx = p1x; lastCy = p1y
+                moved = false
+                handleDrag = false
+                downAt = System.currentTimeMillis()
+                if (inHandle(event.x, event.y)) {
+                    parent?.requestDisallowInterceptTouchEvent(true)
+                    state = STATE_HANDLE
+                    hox = event.x - hx
+                    hoy = event.y - hy
+                    return true
+                }
+                if (!active) {
+                    pid1 = -1
+                    return false // 放行给 WebView：触屏模式零干扰
+                }
+                parent?.requestDisallowInterceptTouchEvent(true)
+                state = STATE_PENDING
+                postDelayed(longPressRunnable, LONG_PRESS_MS)
+                return true
+            }
+
+            MotionEvent.ACTION_POINTER_DOWN -> {
+                if (state == STATE_PENDING || state == STATE_DRAG) {
+                    // 第二指落下 → 进入双指滚轮态（取消长按/点按判定）
+                    if (pid2 == -1 && event.pointerCount >= 2) {
+                        removeCallbacks(longPressRunnable)
+                        pid2 = event.getPointerId(event.actionIndex)
+                        updatePointer(event, pid1)
+                        updatePointer(event, pid2)
+                        lastCx = (p1x + p2x) / 2f
+                        lastCy = (p1y + p2y) / 2f
+                        twoFingerAt = System.currentTimeMillis()
+                        state = STATE_WHEEL
+                        invalidate()
+                        return true
+                    }
+                }
+                return true // 其余情况：多出的手指一律吞掉
+            }
+
+            MotionEvent.ACTION_MOVE -> {
+                updatePointer(event, pid1)
+                updatePointer(event, pid2)
+                when (state) {
+                    STATE_HANDLE -> {
+                        if (Math.hypot((p1x - sx).toDouble(), (p1y - sy).toDouble()) > touchSlop) handleDrag = true
+                        if (handleDrag) {
+                            hx = (p1x - hox).coerceIn(handleR, width - handleR)
+                            hy = (p1y - hoy).coerceIn(handleR, height - handleR)
+                            invalidate()
+                        }
+                    }
+                    STATE_PENDING -> {
+                        if (!moved && Math.hypot((p1x - sx).toDouble(), (p1y - sy).toDouble()) > touchSlop) {
+                            moved = true
+                            removeCallbacks(longPressRunnable)
+                            state = STATE_DRAG
+                            invalidate()
+                        }
+                    }
+                    STATE_DRAG -> {
+                        cnx = (cnx + (p1x - lastCx) * CURSOR_SENS / width).coerceIn(0f, 1f)
+                        cny = (cny + (p1y - lastCy) * CURSOR_SENS / height).coerceIn(0f, 1f)
+                        pendingCssX = cnx * width / density
+                        pendingCssY = cny * height / density
+                        scheduleFlush()
+                        invalidate()
+                    }
+                    STATE_WHEEL -> {
+                        val cxNow = (p1x + p2x) / 2f
+                        val cyNow = (p1y + p2y) / 2f
+                        val dy = cyNow - lastCy
+                        if (Math.hypot((cxNow - lastCx).toDouble(), dy.toDouble()) > touchSlop) moved = true
+                        pendingWheelDelta += -dy * WHEEL_SENS / density
+                        scheduleFlush()
+                    }
+                }
+                lastCx = p1x; lastCy = p1y
+                if (pid2 != -1) { lastCx = (p1x + p2x) / 2f; lastCy = (p1y + p2y) / 2f }
+                return true
+            }
+
+            MotionEvent.ACTION_POINTER_UP -> {
+                val upId = event.getPointerId(event.actionIndex)
+                if (state == STATE_WHEEL && (upId == pid1 || upId == pid2)) {
+                    flushNow()
+                    // 双指快速点按（几乎未移动）= 右键
+                    if (!moved && System.currentTimeMillis() - twoFingerAt < TWO_FINGER_TAP_MS) {
+                        js("rclick", cnx * width / density, cny * height / density)
+                    }
+                    state = STATE_COOLDOWN
+                    if (upId == pid2) pid2 = -1 else pid1 = pid2.also { pid2 = -1 }
+                }
+                return true
+            }
+
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                val upId = event.getPointerId(event.actionIndex)
+                // 只处理被跟踪手指的抬起；未跟踪手指（第三指等）忽略
+                if (event.actionMasked == MotionEvent.ACTION_CANCEL ||
+                    upId == pid1 || upId == pid2
+                ) {
+                    removeCallbacks(longPressRunnable)
+                    val quick = !moved && state == STATE_PENDING &&
+                        System.currentTimeMillis() - downAt < LONG_PRESS_MS
+                    if (event.actionMasked == MotionEvent.ACTION_UP) {
+                        if (state == STATE_HANDLE && !handleDrag) {
+                            setActive(!active)
+                        } else if (quick && active) {
+                            flushNow()
+                            js("click", cnx * width / density, cny * height / density)
+                        } else if (active) {
+                            flushNow() // 拖动/滚轮收尾：立即派发剩余增量，不等 16ms 队列
+                        }
+                    }
+                    if (state == STATE_HANDLE && handleDrag) {
+                        prefs.edit()
+                            .putFloat(KEY_HANDLE_X, hx / width)
+                            .putFloat(KEY_HANDLE_Y, hy / height)
+                            .apply()
+                    }
+                    state = STATE_IDLE
+                    pid1 = -1
+                    pid2 = -1
+                    invalidate()
+                }
+                return true
+            }
+        }
+        return super.onTouchEvent(event)
+    }
+
+    private fun updatePointer(event: MotionEvent, id: Int) {
+        val idx = event.findPointerIndex(id)
+        if (idx < 0) return
+        if (id == pid1) { p1x = event.getX(idx); p1y = event.getY(idx) }
+        else if (id == pid2) { p2x = event.getX(idx); p2y = event.getY(idx) }
+    }
+
+    override fun onDetachedFromWindow() {
+        removeCallbacks(longPressRunnable)
+        removeCallbacks(flushRunnable)
+        super.onDetachedFromWindow()
+    }
+
+    private fun setActive(on: Boolean) {
+        active = on
+        android.util.Log.i("TyranoMouse", "virtual mouse " + if (on) "ON" else "OFF")
+        if (on) {
+            pendingCssX = cnx * width / density
+            pendingCssY = cny * height / density
+            flushNow()
+        } else {
+            pendingCssX = Float.NaN
+        }
+        invalidate()
+    }
+
+    // ============================================================ JS 派发
+
+    private fun scheduleFlush() {
+        if (flushPosted) return
+        flushPosted = true
+        postDelayed(flushRunnable, FLUSH_INTERVAL_MS)
+    }
+
+    private fun flushNow() {
+        if (!java.lang.Float.isNaN(pendingCssX)) {
+            js("move", pendingCssX, pendingCssY)
+            pendingCssX = Float.NaN
+        }
+        if (pendingWheelDelta != 0f) {
+            js("wheel", pendingWheelDelta, cnx * width / density, cny * height / density)
+            pendingWheelDelta = 0f
+        }
+    }
+
+    /** 派发 `window.__tnMouse.<op>(args...)`；NaN/Inf 防御。 */
+    private fun js(op: String, vararg args: Float) {
+        val sb = StringBuilder("window.__tnMouse&&window.__tnMouse.").append(op).append('(')
+        args.forEachIndexed { i, v ->
+            if (i > 0) sb.append(',')
+            val f = if (v.isNaN() || v.isInfinite()) 0f else v
+            sb.append(String.format(Locale.US, "%.1f", f))
+        }
+        sb.append(')')
+        if (op != "move") {
+            android.util.Log.d("TyranoMouse", "dispatch ${sb.substring(sb.indexOf('.') + 1)}")
+        }
+        dispatchJs(sb.toString())
+    }
+
+    private fun inHandle(x: Float, y: Float): Boolean =
+        Math.hypot((x - hx).toDouble(), (y - hy).toDouble()) <= handleR + 6f * density
+}


### PR DESCRIPTION
- VirtualMouseLayer: gesture state machine (single-finger drag=cursor, tap=left-click, long-press 350ms=right-click, two-finger vertical swipe=scroll wheel, two-finger tap=right-click, handle tap=toggle)
- __tyranor_mouse.js: synthetic event API injected into WebView for MV/MZ only, with pageX/pageY compatibility and DOM scroll fallback
- Click uses 50ms hold-release timing to satisfy TouchInput.isRepeated() (isPressed gate in Window_Message.isTriggered)
- Cursor icon: arrow path instead of CSS border-triangle
- Edge clamping on hitElement to prevent html/body fallback
- Dispatch logging at Log.d for non-move events
- Gesture state resets on pause/background to prevent stuck states
- Three-finger edge cases: static guard, short-circuit move

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 为 RPG Maker MV/MZ 游戏新增虚拟鼠标操作层。
  - 支持拖动手柄、相对移动、鼠标光标开关及位置记忆。
  - 支持左键点击、长按右键、双指滚轮和双指快速右键点击。
  - 改善触屏操作与网页元素交互，支持滚动区域操作。
  - 游戏暂停或手势取消时自动重置鼠标状态。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->