### PR TITLE
fix(ui): prevent bottom sheet state leak on rapid swipe-dismiss

### DIFF
--- a/app/src/main/java/com/tyranor/next/ui/pages/GameScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/pages/GameScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
@@ -202,18 +203,20 @@ fun GameScreen(
 
     // ===== 点击游戏卡片的底部抽屉栏 =====
     selectedGame?.let { game ->
-        GameActionsSheet(
-            game = game,
-            onDismiss = { selectedGame = null },
-            onGameUpdated = { replaceGame(it) },
-            onDeleteGame = { deleteGame(game) },
-            quickLaunched = libraryState.quickLaunch.any { it.uri == game.uri },
-            onQuickLaunchToggle = { onQuickLaunchToggle(game) },
-            onEngineSettings = {
-                startActivityWithPageTransition(context, PerGameSettingsActivity.createIntent(context, game))
-                selectedGame = null
-            },
-        )
+        key(game.uri) {
+            GameActionsSheet(
+                game = game,
+                onDismiss = { selectedGame = null },
+                onGameUpdated = { replaceGame(it) },
+                onDeleteGame = { deleteGame(game) },
+                quickLaunched = libraryState.quickLaunch.any { it.uri == game.uri },
+                onQuickLaunchToggle = { onQuickLaunchToggle(game) },
+                onEngineSettings = {
+                    startActivityWithPageTransition(context, PerGameSettingsActivity.createIntent(context, game))
+                    selectedGame = null
+                },
+            )
+        }
     }
 
     // ===== 长按游戏卡片：启动游戏；Artemis 按既有策略弹出补丁确认 =====

--- a/app/src/main/java/com/tyranor/next/ui/pages/HomeScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/pages/HomeScreen.kt
@@ -190,18 +190,20 @@ fun HomeScreen(
 
     // ===== 与游戏页统一：点按打开操作抽屉，长按直接启动 =====
     selectedGame?.let { game ->
-        GameActionsSheet(
-            game = game,
-            onDismiss = { selectedGame = null },
-            onGameUpdated = { replaceGame(it) },
-            onDeleteGame = { deleteGame(game) },
-            quickLaunched = quickLaunch.any { it.uri == game.uri },
-            onQuickLaunchToggle = { onQuickLaunchToggle(game) },
-            onEngineSettings = {
-                startActivityWithPageTransition(context, PerGameSettingsActivity.createIntent(context, game))
-                selectedGame = null
-            },
-        )
+        key(game.uri) {
+            GameActionsSheet(
+                game = game,
+                onDismiss = { selectedGame = null },
+                onGameUpdated = { replaceGame(it) },
+                onDeleteGame = { deleteGame(game) },
+                quickLaunched = quickLaunch.any { it.uri == game.uri },
+                onQuickLaunchToggle = { onQuickLaunchToggle(game) },
+                onEngineSettings = {
+                    startActivityWithPageTransition(context, PerGameSettingsActivity.createIntent(context, game))
+                    selectedGame = null
+                },
+            )
+        }
     }
 
     // ===== Artemis 首次启动补丁确认（与游戏页一致） =====


### PR DESCRIPTION
## 问题

游戏页/首页点击游戏弹出底部操作菜单后，快速下滑关闭再立刻点击另一个游戏，新游戏的菜单会闪现后立刻缩回、无法操作。

## 原因

`ModalBottomSheet` 内部的 `sheetState`（由 `rememberModalBottomSheetState` 持有）在 sheet 离开 composition 后仍通过 `remember` 存活。快速 dismiss 时 `sheetState` 还在跑 dismiss 动画（\~300ms），此时新 sheet 复用同一个 `sheetState`，两个方向相反的动画冲突导致菜单卡死。

## 修复

在 GameScreen 和 HomeScreen 的 `GameActionsSheet` 外层加 `key(game.uri)`，确保每次切换游戏时 composition 销毁重建，`sheetState` 不再跨实例复用。

## 改动

- `GameScreen.kt`: `GameActionsSheet` 包裹 `key(game.uri)`
- `HomeScreen.kt`: `GameActionsSheet` 包裹 `key(game.uri)`（同上）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复游戏操作底部抽屉在切换游戏时状态未正确更新的问题。
  * 现在每个游戏的抽屉状态会与对应游戏关联，避免显示错误或残留的操作内容。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->