### PR TITLE
fix(ui): GameActionsSheet 快速滑动抖动修复（#27）

### DIFF
--- a/app/src/main/java/com/tyranor/next/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/game/GameScreen.kt
@@ -71,6 +71,7 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
@@ -531,11 +532,18 @@ internal fun GameActionsSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
         containerColor = MaterialTheme.colorScheme.background,
+        contentWindowInsets = { WindowInsets(0.dp) },
     ) {
+        // 小平板横屏下屏幕高度可能 < 560dp，硬编码会导致抽屉填满屏幕，
+        // SwipeableState 无法区分滚动/收起，快速滑动时高速振荡（issue #27）。
+        val sheetMaxHeight = with(LocalConfiguration.current) {
+            val available = (screenHeightDp - 120).dp
+            available.coerceIn(200.dp, 560.dp)
+        }
         LazyColumn(
             modifier = Modifier
                 .fillMaxWidth()
-                .heightIn(max = GameActionsSheetMaxHeight),
+                .heightIn(max = sheetMaxHeight),
             contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
@@ -747,8 +755,6 @@ internal fun GameActionsSheet(
         )
     }
 }
-
-private val GameActionsSheetMaxHeight: Dp = 560.dp
 
 @Composable
 private fun RenameGameDialog(


### PR DESCRIPTION
## 修复内容

- 添加 `contentWindowInsets = { WindowInsets(0.dp) }` 到 `GameActionsSheet` 的 `ModalBottomSheet`
- 小平板横屏下限制 sheet 最大高度为 `min(屏幕高度-120dp, 560dp)`

## 根因

Material 3 `ModalBottomSheet` 默认 `contentWindowInsets` 导致 `AnchoredDraggable` 速度追踪与布局测量在快速 fling 时产生竞争条件。默认 insets 导致 expanded anchor 被错误偏移，速度衰减后 sheet 在 Expanded/Hidden 之间无限弹跳。

Fixes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化游戏操作底部抽屉的窗口适配表现。
  - 底部抽屉高度将根据屏幕尺寸动态调整，在不同设备上提供更合适的显示空间。
  - 限制抽屉高度范围，避免内容区域过大或过小。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->