### PR TITLE
feat(rpgmaker): 触屏手柄键盘布局自定义、预设与预览

### DIFF
--- a/app/src/main/java/com/tyranor/next/core/settings/PerGameSettingsStore.kt
+++ b/app/src/main/java/com/tyranor/next/core/settings/PerGameSettingsStore.kt
@@ -1,6 +1,7 @@
 package com.tyranor.next.core.settings
 
 import android.content.Context
+import com.core.engine.EnginePrefs
 import org.json.JSONObject
 
 /**
@@ -10,7 +11,9 @@ import org.json.JSONObject
  */
 object PerGameSettingsStore {
 
-    private const val PREF_NAME = "tyranor_game_overrides"
+    // prefs 文件名契约锚点在 engine（引擎 TyranoActivity/TouchPadSaveBridge 直读写同一文件），
+    // 改名只需改 EnginePrefs 一处。
+    private val PREF_NAME = EnginePrefs.GAME_OVERRIDES_PREFS
 
     // KR 覆盖字段名
     const val F_ENGINE_VERSION = "engine_version"
@@ -38,7 +41,6 @@ object PerGameSettingsStore {
 
     // RPG Maker MV/MZ
     const val F_RPG_MAKER_MOD_ENABLED = "rpg_maker_mod_enabled"
-    const val F_TOUCH_PAD_CONFIG = "touch_pad_config"
 
     // ONS 子对象键
     const val ONS_KEY = "ons"
@@ -106,18 +108,6 @@ object PerGameSettingsStore {
     fun clear(context: Context, gameId: String) {
         if (gameId.isBlank()) return
         prefs(context).edit().remove(gameId).apply()
-    }
-
-    /** 读取触屏手柄配置 JSON；null=使用默认布局。 */
-    fun getTouchPadConfig(context: Context, gameId: String): String? {
-        if (gameId.isBlank()) return null
-        return getStr(context, gameId, F_TOUCH_PAD_CONFIG)
-    }
-
-    /** 保存触屏手柄配置 JSON。null=移除自定义（恢复默认）。 */
-    fun setTouchPadConfig(context: Context, gameId: String, json: String?) {
-        if (gameId.isBlank()) return
-        setStr(context, gameId, F_TOUCH_PAD_CONFIG, json)
     }
 
     private fun persist(context: Context, gameId: String, json: JSONObject) {

--- a/app/src/main/java/com/tyranor/next/core/settings/PerGameSettingsStore.kt
+++ b/app/src/main/java/com/tyranor/next/core/settings/PerGameSettingsStore.kt
@@ -38,6 +38,7 @@ object PerGameSettingsStore {
 
     // RPG Maker MV/MZ
     const val F_RPG_MAKER_MOD_ENABLED = "rpg_maker_mod_enabled"
+    const val F_TOUCH_PAD_CONFIG = "touch_pad_config"
 
     // ONS 子对象键
     const val ONS_KEY = "ons"
@@ -105,6 +106,18 @@ object PerGameSettingsStore {
     fun clear(context: Context, gameId: String) {
         if (gameId.isBlank()) return
         prefs(context).edit().remove(gameId).apply()
+    }
+
+    /** 读取触屏手柄配置 JSON；null=使用默认布局。 */
+    fun getTouchPadConfig(context: Context, gameId: String): String? {
+        if (gameId.isBlank()) return null
+        return getStr(context, gameId, F_TOUCH_PAD_CONFIG)
+    }
+
+    /** 保存触屏手柄配置 JSON。null=移除自定义（恢复默认）。 */
+    fun setTouchPadConfig(context: Context, gameId: String, json: String?) {
+        if (gameId.isBlank()) return
+        setStr(context, gameId, F_TOUCH_PAD_CONFIG, json)
     }
 
     private fun persist(context: Context, gameId: String, json: JSONObject) {

--- a/app/src/main/java/com/tyranor/next/ui/common/AppSearchField.kt
+++ b/app/src/main/java/com/tyranor/next/ui/common/AppSearchField.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
@@ -15,6 +16,7 @@ import com.tyranor.next.theme.MiuixSettingsTheme
 import top.yukonga.miuix.kmp.basic.InputField
 import top.yukonga.miuix.kmp.basic.SearchBar
 import top.yukonga.miuix.kmp.basic.SearchBarDefaults
+import top.yukonga.miuix.kmp.theme.LocalContentColor
 import top.yukonga.miuix.kmp.theme.MiuixTheme
 
 /**
@@ -45,7 +47,11 @@ fun AppSearchField(
     textStyle: TextStyle? = null,
 ) {
     MiuixSettingsTheme {
-        SearchBar(
+        // miuix 无 controller 的 MiuixTheme 重载不提供 LocalContentColor（默认黑色），
+        // InputField 内部强制以 LocalContentColor.current 作为输入文字颜色，
+        // 此处显式提供主题 onBackground（深色=白色系 / 浅色=深灰），保证深浅色下文字正确。
+        CompositionLocalProvider(LocalContentColor provides MiuixTheme.colorScheme.onBackground) {
+            SearchBar(
             inputField = {
                 InputField(
                     query = query,
@@ -71,6 +77,7 @@ fun AppSearchField(
             onExpandedChange = { },
             modifier = modifier.fillMaxWidth(),
             content = { },
-        )
+            )
+        }
     }
 }

--- a/app/src/main/java/com/tyranor/next/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/game/GameScreen.kt
@@ -780,6 +780,7 @@ private fun RenameGameDialog(
                 onSearch = { if (canConfirm) onConfirm(normalizedTitle) },
                 leadingIcon = painterResource(R.drawable.ic_sheet_rename),
                 iconContentDescription = "Rename",
+                textStyle = MaterialTheme.typography.bodyMedium,
             )
         },
         confirmButton = {

--- a/engine/src/main/assets/__rpgmaker_mod_ui.js
+++ b/engine/src/main/assets/__rpgmaker_mod_ui.js
@@ -145,6 +145,23 @@
     content.innerHTML = card("触屏手柄", hasPad
       ? '<p>自定义屏幕上虚拟键的位置、大小与显隐。进入映射后：</p><ul style="margin:6px 0 10px;padding-left:18px;font-size:12px"><li>拖拽按钮调整位置</li><li>缩放进度条调整大小（1%-200%）</li><li>“透明”隐藏按钮</li><li>十字键微调位置</li></ul><div class="tm-row">' + button("进入键盘映射", "enter-keys", "primary") + button("恢复默认", "reset-keys") + '</div>'
       : '<p>当前未加载触屏手柄。</p>');
+    if (!hasPad) return;
+    var names;
+    try { names = window.__touchPad.listPresets(); } catch (e) { names = []; }
+    if (names && names.length) {
+      var rows = names.map(function (name) {
+        var esc = escapeHtml(name).replace(/"/g, "&quot;");
+        return '<div class="tm-row" style="justify-content:space-between">' +
+          '<label style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;margin:0">' + escapeHtml(name) + '</label>' +
+          '<span style="display:flex;gap:6px">' +
+          button("预览", "preview-preset", "", 'data-name="' + esc + '"') +
+          button("载入", "load-preset", "", 'data-name="' + esc + '"') +
+          '</span></div>';
+      }).join("");
+      content.innerHTML += card("预设（" + names.length + "/10）", rows);
+    } else {
+      content.innerHTML += card("预设", '<p>暂无预设。在键盘映射面板中可保存当前布局为预设。</p>');
+    }
   }
   function handleAction(action, node) {
     if (action === "close") return close();
@@ -183,6 +200,29 @@
       try {
         window.__touchPad.resetToDefaults();
         toast("已恢复默认");
+      } catch (e) { toast(String(e && e.message || e), true); }
+      return;
+    }
+    if (action === "preview-preset") {
+      if (!window.__touchPad) { toast("未加载触屏手柄", true); return; }
+      var pname = node.dataset.name;
+      close();
+      setTimeout(function () {
+        try {
+          var res = window.__touchPad.previewPreset(pname);
+          if (res && res.ok === false) toast(res.msg, true);
+        } catch (e) { toast(String(e && e.message || e), true); }
+      }, 50);
+      return;
+    }
+    if (action === "load-preset") {
+      if (!window.__touchPad) { toast("未加载触屏手柄", true); return; }
+      var lname = node.dataset.name;
+      try {
+        var lres = window.__touchPad.loadPreset(lname);
+        if (lres && lres.ok) toast(lres.msg);
+        else toast(lres && lres.msg || "载入失败", true);
+        renderKeys(root.querySelector(".tm-content"));
       } catch (e) { toast(String(e && e.message || e), true); }
       return;
     }

--- a/engine/src/main/assets/__rpgmaker_mod_ui.js
+++ b/engine/src/main/assets/__rpgmaker_mod_ui.js
@@ -12,7 +12,7 @@
   var context = { actorId: 0, itemKind: "item", systemKind: "switch" };
   var tabs = [
     ["quick", "快捷"], ["items", "物品"], ["actors", "角色"], ["system", "系统"],
-    ["map", "地图"], ["battle", "战斗"], ["save", "存档"], ["keys", "键盘"]
+    ["map", "地图"], ["battle", "战斗"], ["save", "存档"], ["keys", "键盘"], ["about", "说明"]
   ];
   var flags = [
     ["godMode", "无敌"], ["oneHit", "一击必杀"], ["alwaysCrit", "必定暴击"],
@@ -150,7 +150,8 @@
     try { names = window.__touchPad.listPresets(); } catch (e) { names = []; }
     if (names && names.length) {
       var rows = names.map(function (name) {
-        var esc = escapeHtml(name).replace(/"/g, "&quot;");
+        // escapeHtml 已覆盖引号转义，data-name 属性可直接使用
+        var esc = escapeHtml(name);
         return '<div class="tm-row" style="justify-content:space-between">' +
           '<label style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;margin:0">' + escapeHtml(name) + '</label>' +
           '<span style="display:flex;gap:6px">' +

--- a/engine/src/main/assets/__rpgmaker_mod_ui.js
+++ b/engine/src/main/assets/__rpgmaker_mod_ui.js
@@ -12,7 +12,7 @@
   var context = { actorId: 0, itemKind: "item", systemKind: "switch" };
   var tabs = [
     ["quick", "快捷"], ["items", "物品"], ["actors", "角色"], ["system", "系统"],
-    ["map", "地图"], ["battle", "战斗"], ["save", "存档"], ["about", "说明"]
+    ["map", "地图"], ["battle", "战斗"], ["save", "存档"], ["keys", "键盘"]
   ];
   var flags = [
     ["godMode", "无敌"], ["oneHit", "一击必杀"], ["alwaysCrit", "必定暴击"],
@@ -49,6 +49,7 @@
     else if (activeTab === "map") renderMap(content);
     else if (activeTab === "battle") renderBattle(content);
     else if (activeTab === "save") renderSave(content);
+    else if (activeTab === "keys") renderKeys(content);
     else renderAbout(content);
   }
   function renderQuick(content) {
@@ -139,6 +140,12 @@
   function renderAbout(content) {
     content.innerHTML = card("Tyranor 修改器", '<p>版本 ' + escapeHtml(mod.version) + '</p><p>修改器只操作当前 RPG Maker MV/MZ 游戏的运行时对象。部分深度定制插件可能覆盖标准引擎 API；遇到异常时可在单游戏设置中关闭修改器。</p><p>事件加速和对话快进可能跳过演出或等待，建议先保存游戏。</p>');
   }
+  function renderKeys(content) {
+    var hasPad = !!(window.__touchPad);
+    content.innerHTML = card("触屏手柄", hasPad
+      ? '<p>自定义屏幕上虚拟键的位置、大小与显隐。进入映射后：</p><ul style="margin:6px 0 10px;padding-left:18px;font-size:12px"><li>拖拽按钮调整位置</li><li>缩放进度条调整大小（1%-200%）</li><li>“透明”隐藏按钮</li><li>十字键微调位置</li></ul><div class="tm-row">' + button("进入键盘映射", "enter-keys", "primary") + button("恢复默认", "reset-keys") + '</div>'
+      : '<p>当前未加载触屏手柄。</p>');
+  }
   function handleAction(action, node) {
     if (action === "close") return close();
     if (action === "render") return render();
@@ -165,6 +172,20 @@
     if (action === "save") return run(function () { return mod.saveGame(node.dataset.id); }, function () { toast("保存完成"); renderSave(root.querySelector(".tm-content")); });
     if (action === "load") return run(function () { return mod.loadGame(node.dataset.id); }, function () { toast("读取完成"); close(); });
     if (action === "delete-save") return run(function () { return mod.deleteSave(node.dataset.id); }, function () { toast("存档已删除"); renderSave(root.querySelector(".tm-content")); });
+    if (action === "enter-keys") {
+      if (!window.__touchPad) { toast("未加载触屏手柄", true); return; }
+      close();
+      setTimeout(function () { try { window.__touchPad.enterEdit(); } catch (e) { toast(String(e && e.message || e), true); } }, 50);
+      return;
+    }
+    if (action === "reset-keys") {
+      if (!window.__touchPad) { toast("未加载触屏手柄", true); return; }
+      try {
+        window.__touchPad.resetToDefaults();
+        toast("已恢复默认");
+      } catch (e) { toast(String(e && e.message || e), true); }
+      return;
+    }
   }
   function block(event) {
     if (!root) return;

--- a/engine/src/main/assets/__touch_pad.js
+++ b/engine/src/main/assets/__touch_pad.js
@@ -328,8 +328,9 @@ window.addEventListener('load', () => {
         display: isKeysShown ? 'block' : 'none'
       })
       if (custom && custom.x != null && custom.y != null) {
-        el.style.left = `${custom.x}px`
-        el.style.top = `${custom.y}px`
+        const r0 = el.getBoundingClientRect()
+        el.style.left = `${custom.x - r0.width / 2}px`
+        el.style.top = `${custom.y - r0.height / 2}px`
       }
     })
     qwzxEls.forEach(el => {
@@ -343,10 +344,11 @@ window.addEventListener('load', () => {
       }
       el.style.display = isKeysShown ? 'block' : 'none'
       if (custom && custom.x != null && custom.y != null) {
+        const r0 = el.getBoundingClientRect()
         const pr = qwzxElement.getBoundingClientRect()
         el.style.transform = scale === 1 ? '' : `scale(${scale})`
-        el.style.left = `${custom.x - pr.left}px`
-        el.style.top = `${custom.y - pr.top}px`
+        el.style.left = `${custom.x - r0.width / 2 - pr.left}px`
+        el.style.top = `${custom.y - r0.height / 2 - pr.top}px`
         el.style.right = 'auto'
         el.style.transformOrigin = 'center'
       } else {
@@ -386,6 +388,7 @@ window.addEventListener('load', () => {
   }
   const setEventStart = (e, keyCodes) => {
     const press = (evt) => {
+      if (editMode) return
       evt.stopPropagation()
       evt.preventDefault()
       setKeyDownColor(e)
@@ -407,6 +410,7 @@ window.addEventListener('load', () => {
   }
   const setEventEnd = (e, keyCodes) => {
     const release = (evt) => {
+      if (editMode) return
       evt.stopPropagation()
       evt.preventDefault()
       setKeyUpColor(e)
@@ -657,19 +661,18 @@ window.addEventListener('load', () => {
       }
       entry.el.style.display = 'block'
       if (custom && custom.x != null && custom.y != null) {
+        var r0 = entry.el.getBoundingClientRect()
+        entry.el.style.transform = scale === 1 ? '' : 'scale(' + scale + ')'
+        entry.el.style.transformOrigin = 'center'
         if (entry.el.__group === 'qwzx') {
           var pr = qwzxElement.getBoundingClientRect()
-          entry.el.style.transform = scale === 1 ? '' : 'scale(' + scale + ')'
-          entry.el.style.left = (custom.x - pr.left) + 'px'
-          entry.el.style.top = (custom.y - pr.top) + 'px'
-          entry.el.style.right = 'auto'
+          entry.el.style.left = (custom.x - r0.width / 2 - pr.left) + 'px'
+          entry.el.style.top = (custom.y - r0.height / 2 - pr.top) + 'px'
         } else {
-          entry.el.style.transform = scale === 1 ? '' : 'scale(' + scale + ')'
-          entry.el.style.left = custom.x + 'px'
-          entry.el.style.top = custom.y + 'px'
-          entry.el.style.right = 'auto'
+          entry.el.style.left = (custom.x - r0.width / 2) + 'px'
+          entry.el.style.top = (custom.y - r0.height / 2) + 'px'
         }
-        entry.el.style.transformOrigin = 'center'
+        entry.el.style.right = 'auto'
       } else {
         // 复用 layout 的默认定位：先恢复列布局，再应用 scale
         entry.el.style.left = ''
@@ -722,13 +725,17 @@ window.addEventListener('load', () => {
   }
 
   function buildPanel() {
-    var style = document.createElement('style')
-    style.textContent =
-      '.tm-pad-editable{cursor:move}' +
-      '.tm-pad-btn{background:#3a3a4a;color:#fff;border:1px solid #666;border-radius:6px;padding:5px 10px;cursor:pointer;font:13px sans-serif}' +
-      '.tm-pad-btn.primary{background:#2b6cb0}' +
-      '.tm-pad-nudge{background:#3a3a4a;color:#fff;border:1px solid #666;border-radius:5px;width:26px;height:26px;cursor:pointer;font:14px sans-serif}'
-    document.body.appendChild(style)
+    var style = document.getElementById('tm-pad-edit-css')
+    if (!style) {
+      style = document.createElement('style')
+      style.id = 'tm-pad-edit-css'
+      style.textContent =
+        '.tm-pad-editable{cursor:move}' +
+        '.tm-pad-btn{background:#3a3a4a;color:#fff;border:1px solid #666;border-radius:6px;padding:5px 10px;cursor:pointer;font:13px sans-serif}' +
+        '.tm-pad-btn.primary{background:#2b6cb0}' +
+        '.tm-pad-nudge{background:#3a3a4a;color:#fff;border:1px solid #666;border-radius:5px;width:26px;height:26px;cursor:pointer;font:14px sans-serif}'
+      document.body.appendChild(style)
+    }
     panel = document.createElement('div')
     panel.className = 'tm-pad-editpanel'
     panel.style.cssText = [
@@ -778,7 +785,7 @@ window.addEventListener('load', () => {
     slider.addEventListener('input', function () {
       if (!selectedId) return
       var c = ensureButtonCfg(selectedId)
-      if (c.x == null && c.y == null) { var r = getElById(selectedId).getBoundingClientRect(); c.x = r.left; c.y = r.top }
+      if (c.x == null && c.y == null) { var r = getElById(selectedId).getBoundingClientRect(); c.x = r.left + r.width / 2; c.y = r.top + r.height / 2 }
       c.scale = Number(slider.value) / 100
       refreshEditConfig()
       setSelected(selectedId)
@@ -789,8 +796,8 @@ window.addEventListener('load', () => {
         var c = ensureButtonCfg(selectedId)
         var el = getElById(selectedId)
         var pr = el.getBoundingClientRect()
-        c.x = pr.left
-        c.y = pr.top
+        c.x = pr.left + pr.width / 2
+        c.y = pr.top + pr.height / 2
         var d = b.getAttribute('data-d')
         if (d === 'up') c.y -= NUDGE
         else if (d === 'down') c.y += NUDGE
@@ -855,8 +862,8 @@ window.addEventListener('load', () => {
       if (!c || c.x == null || c.y == null) {
         var r = entry.el.getBoundingClientRect()
         editConfig.buttons[meta.id] = c || defaultButtonFor(meta.id)
-        editConfig.buttons[meta.id].x = r.left
-        editConfig.buttons[meta.id].y = r.top
+        editConfig.buttons[meta.id].x = r.left + r.width / 2
+        editConfig.buttons[meta.id].y = r.top + r.height / 2
       }
     })
     refreshEditConfig()
@@ -877,8 +884,8 @@ window.addEventListener('load', () => {
       var c = ensureButtonCfg(meta.id)
       c.visible = true
       var r = el.getBoundingClientRect()
-      c.x = r.left
-      c.y = r.top
+      c.x = r.left + r.width / 2
+      c.y = r.top + r.height / 2
       drag = { id: meta.id, ox: ev.clientX, oy: ev.clientY, bx: c.x, by: c.y, moved: false }
     }
     function onMove(ev) {

--- a/engine/src/main/assets/__touch_pad.js
+++ b/engine/src/main/assets/__touch_pad.js
@@ -43,6 +43,20 @@ window.addEventListener('load', () => {
   document.body.appendChild(joyStickStage)
   joyStickStage.appendChild(joyStick)
   document.body.appendChild(udlrElement)
+
+  // issue #30：自定义布局。window.__touchPadConfig 由 TyranoActivity 按游戏注入：
+  // { buttons: { <id>: { x, y, scale, visible } } }
+  let padConfig = null
+  try {
+    const raw = window.__touchPadConfig
+    if (raw && typeof raw === 'object' && raw.buttons) padConfig = raw
+  } catch (e) { /* 忽略坏配置，回退默认 */ }
+  const btnScale = (custom) => {
+    const s = custom && custom.scale != null ? Number(custom.scale) : 1
+    if (!isFinite(s) || s <= 0) return 1
+    return Math.min(2, Math.max(0.01, s))
+  }
+
   const keyCodes = {
     Tab: 9,
     Enter: 13,
@@ -63,42 +77,15 @@ window.addEventListener('load', () => {
     Z: 90
   }
   const actionsBtns = [
-    {
-      text: 'PageUp',
-      keyCode: keyCodes.PageUp
-    },
-    {
-      text: 'PageDown',
-      keyCode: keyCodes.PageDown
-    },
-    {
-      text: 'Tab',
-      keyCode: keyCodes.Tab
-    },
-    {
-      text: 'Alt',
-      keyCode: keyCodes.Alt
-    },
-    {
-      text: 'Ctrl',
-      keyCode: keyCodes.Ctrl
-    },
-    {
-      text: 'Shift',
-      keyCode: keyCodes.Shift
-    },
-    {
-      text: 'Space',
-      keyCode: keyCodes.Space
-    },
-    {
-      text: 'Enter',
-      keyCode: keyCodes.Enter
-    },
-    {
-      text: 'Esc',
-      keyCode: keyCodes.Esc
-    }
+    { id: 'pageup', text: 'PageUp', keyCode: keyCodes.PageUp },
+    { id: 'pagedown', text: 'PageDown', keyCode: keyCodes.PageDown },
+    { id: 'tab', text: 'Tab', keyCode: keyCodes.Tab },
+    { id: 'alt', text: 'Alt', keyCode: keyCodes.Alt },
+    { id: 'ctrl', text: 'Ctrl', keyCode: keyCodes.Ctrl },
+    { id: 'shift', text: 'Shift', keyCode: keyCodes.Shift },
+    { id: 'space', text: 'Space', keyCode: keyCodes.Space },
+    { id: 'enter', text: 'Enter', keyCode: keyCodes.Enter },
+    { id: 'esc', text: 'Esc', keyCode: keyCodes.Esc }
   ]
   const udlrBtns = [
     {
@@ -203,42 +190,10 @@ window.addEventListener('load', () => {
     }
   ]
   const qwzxBtns = [
-    {
-      text: 'Q',
-      keyCode: keyCodes.Q,
-      style: {
-        transform: 'translate(0%,-50%)',
-        left: '0%',
-        top: '50%'
-      }
-    },
-    {
-      text: 'W',
-      keyCode: keyCodes.W,
-      style: {
-        transform: 'translate(-50%,0%)',
-        left: '50%',
-        top: '0%'
-      }
-    },
-    {
-      text: 'Z',
-      keyCode: keyCodes.Z,
-      style: {
-        transform: 'translate(-50%,-100%)',
-        left: '50%',
-        top: '100%'
-      }
-    },
-    {
-      text: 'X',
-      keyCode: keyCodes.X,
-      style: {
-        transform: 'translate(-100%,-50%)',
-        left: '100%',
-        top: '50%'
-      }
-    }
+    { id: 'q', text: 'Q', keyCode: keyCodes.Q, style: { transform: 'translate(0%,-50%)', left: '0%', top: '50%' } },
+    { id: 'w', text: 'W', keyCode: keyCodes.W, style: { transform: 'translate(-50%,0%)', left: '50%', top: '0%' } },
+    { id: 'z', text: 'Z', keyCode: keyCodes.Z, style: { transform: 'translate(-50%,-100%)', left: '50%', top: '100%' } },
+    { id: 'x', text: 'X', keyCode: keyCodes.X, style: { transform: 'translate(-100%,-50%)', left: '100%', top: '50%' } }
   ]
   const commonStyle = {
     position: 'absolute',
@@ -267,6 +222,7 @@ window.addEventListener('load', () => {
   }
 
   let actionEls = []
+  const qwzxEls = []
   function layout() {
     const g = gameRect()
     const r = g.rect
@@ -349,7 +305,15 @@ window.addEventListener('load', () => {
     })
     const btnW = padSize * 0.5
     const pitch = actionBtnH() + 5
+    const activeCfg = (editMode ? editConfig : padConfig)
     actionEls.forEach((el, i) => {
+      const meta = el.__pad || {}
+      const custom = activeCfg && activeCfg.buttons && activeCfg.buttons[meta.id]
+      const scale = btnScale(custom)
+      if (custom && custom.visible === false) {
+        el.style.display = 'none'
+        return
+      }
       Object.assign(el.style, {
         ...btnStyle,
         width: `${btnW}px`,
@@ -359,8 +323,35 @@ window.addEventListener('load', () => {
         right: 'auto',
         left: `${r.left + r.width - allMargin - btnW}px`,
         top: `${r.top + allMargin + i * pitch}px`,
+        transform: scale === 1 ? '' : `scale(${scale})`,
+        transformOrigin: 'center',
         display: isKeysShown ? 'block' : 'none'
       })
+      if (custom && custom.x != null && custom.y != null) {
+        el.style.left = `${custom.x}px`
+        el.style.top = `${custom.y}px`
+      }
+    })
+    qwzxEls.forEach(el => {
+      const meta = el.__pad || {}
+      const activeCfgQ = (editMode ? editConfig : padConfig)
+      const custom = activeCfgQ && activeCfgQ.buttons && activeCfgQ.buttons[meta.id]
+      const scale = btnScale(custom)
+      if (custom && custom.visible === false) {
+        el.style.display = 'none'
+        return
+      }
+      el.style.display = isKeysShown ? 'block' : 'none'
+      if (custom && custom.x != null && custom.y != null) {
+        const pr = qwzxElement.getBoundingClientRect()
+        el.style.transform = scale === 1 ? '' : `scale(${scale})`
+        el.style.left = `${custom.x - pr.left}px`
+        el.style.top = `${custom.y - pr.top}px`
+        el.style.right = 'auto'
+        el.style.transformOrigin = 'center'
+      } else {
+        el.style.transform = (scale === 1 ? '' : `scale(${scale})`) + (el.__baseTransform || '')
+      }
     })
     // 发布动作键列区域，供修改器悬浮球避让（见 __rpgmaker_mod_ui.js）
     window.__touchPadMetrics = {
@@ -572,6 +563,7 @@ window.addEventListener('load', () => {
     const childElement = document.createElement('div')
     actionsElement.appendChild(childElement)
     childElement.innerText = it.text
+    childElement.__pad = { id: it.id, text: it.text, defaultKeyCode: it.keyCode }
     actionEls.push(childElement)
     setEventStart(childElement, [it.keyCode])
     setEventMove(childElement)
@@ -600,6 +592,9 @@ window.addEventListener('load', () => {
       borderRadius: '50em',
       ...it.style
     })
+    childElement.__pad = { id: it.id, text: it.text, defaultKeyCode: it.keyCode }
+    childElement.__baseTransform = it.style.transform || ''
+    qwzxEls.push(childElement)
     setEventStart(childElement, [it.keyCode])
     setEventMove(childElement)
     setEventEnd(childElement, [it.keyCode])
@@ -608,6 +603,361 @@ window.addEventListener('load', () => {
     Object.assign(tElement.style, textStyle)
     tElement.innerText = it.text
   })
+
+  // ================= issue #30：游戏内按钮自定义（进入键盘映射） =================
+  var editMode = false
+  var selectedId = null
+  var editConfig = null        // 编辑中的工作副本 { buttons: { id: {...} } }
+  var overlay = null
+  var panel = null
+  var panelGrab = null         // 顶层控制框拖拽状态
+  var NUDGE = 4
+  var allEditableEls = []      // [{ el, id }]
+
+  function collectEditable() {
+    allEditableEls = []
+    actionEls.forEach(el => { if (el.__pad) allEditableEls.push({ el: el, id: el.__pad.id }) })
+    qwzxEls.forEach(el => { if (el.__pad) allEditableEls.push({ el: el, id: el.__pad.id }) })
+  }
+
+  function defaultButtonFor(id) {
+    var found = actionsBtns.concat(qwzxBtns).filter(function (b) { return b.id === id })[0]
+    return found && { x: null, y: null, scale: 1, visible: true, keyCode: found.keyCode, label: found.text }
+  }
+
+  function ensureButtonCfg(id) {
+    if (!editConfig) editConfig = { buttons: {} }
+    if (!editConfig.buttons[id]) editConfig.buttons[id] = defaultButtonFor(id)
+    return editConfig.buttons[id]
+  }
+
+  function panelRect(el) {
+    var r = el.getBoundingClientRect()
+    return { cx: r.left + r.width / 2, cy: r.top + r.height / 2, w: r.width, h: r.height }
+  }
+
+  function styleButton(el, highlight) {
+    var meta = el.__pad || {}
+    var custom = editConfig && editConfig.buttons && editConfig.buttons[meta.id]
+    var scale = btnScale(custom)
+    el.classList.add('tm-pad-editable')
+    el.style.outline = highlight ? '3px solid #fff' : ''
+    el.style.zIndex = (highlight ? '100000002' : '100000001')
+  }
+
+  function refreshEditConfig() {
+    collectEditable()
+    allEditableEls.forEach(function (entry) {
+      var meta = entry.el.__pad || {}
+      var custom = editConfig && editConfig.buttons && editConfig.buttons[meta.id]
+      var scale = btnScale(custom)
+      if (custom && custom.visible === false) {
+        entry.el.style.display = 'none'
+        return
+      }
+      entry.el.style.display = 'block'
+      if (custom && custom.x != null && custom.y != null) {
+        if (entry.el.__group === 'qwzx') {
+          var pr = qwzxElement.getBoundingClientRect()
+          entry.el.style.transform = scale === 1 ? '' : 'scale(' + scale + ')'
+          entry.el.style.left = (custom.x - pr.left) + 'px'
+          entry.el.style.top = (custom.y - pr.top) + 'px'
+          entry.el.style.right = 'auto'
+        } else {
+          entry.el.style.transform = scale === 1 ? '' : 'scale(' + scale + ')'
+          entry.el.style.left = custom.x + 'px'
+          entry.el.style.top = custom.y + 'px'
+          entry.el.style.right = 'auto'
+        }
+        entry.el.style.transformOrigin = 'center'
+      } else {
+        // 复用 layout 的默认定位：先恢复列布局，再应用 scale
+        entry.el.style.left = ''
+        entry.el.style.top = ''
+        entry.el.style.right = ''
+        if (entry.el.__group === 'qwzx') {
+          entry.el.style.transform = (scale === 1 ? '' : 'scale(' + scale + ')') + (entry.el.__baseTransform || '')
+        } else {
+          entry.el.style.transform = scale === 1 ? '' : 'scale(' + scale + ')'
+        }
+      }
+      if (entry.el.__group !== 'qwzx') entry.el.style.display = 'block'
+    })
+  }
+
+  function setSelected(id) {
+    selectedId = id
+    allEditableEls.forEach(function (entry) { styleButton(entry.el, entry.id === id) })
+    var custom = editConfig.buttons && editConfig.buttons[id]
+    var slider = panel && panel.querySelector('.tm-pad-scale')
+    if (slider) slider.value = String(Math.round(btnScale(custom) * 100))
+    var scaleLabel = panel && panel.querySelector('.tm-pad-scaleval')
+    if (scaleLabel) scaleLabel.textContent = Math.round(btnScale(custom) * 100) + '%'
+    var visLabel = panel && panel.querySelector('.tm-pad-vislabel')
+    if (visLabel) visLabel.textContent = custom && custom.visible === false ? '（已隐藏）' : ''
+  }
+
+  function saveAndExit(force) {
+    if (!editMode) return
+    var small = allEditableEls.filter(function (entry) {
+      var c = editConfig.buttons && editConfig.buttons[entry.id]
+      return c && c.visible !== false && btnScale(c) < 0.5
+    })
+    var doSave = function () {
+      padConfig = editConfig
+      // 持久化到原生
+      try {
+        if (window && window.TyranorTouchPadNative && window.TyranorTouchPadNative.saveConfig) {
+          window.TyranorTouchPadNative.saveConfig(JSON.stringify(padConfig))
+        }
+      } catch (e) { /* 忽略 */ }
+      exitEdit()
+      layout()
+    }
+    if (!force && small.length > 0) {
+      if (window.confirm('有 ' + small.length + ' 个按钮缩放小于 50%，确认保存？')) doSave()
+    } else {
+      doSave()
+    }
+  }
+
+  function buildPanel() {
+    var style = document.createElement('style')
+    style.textContent =
+      '.tm-pad-editable{cursor:move}' +
+      '.tm-pad-btn{background:#3a3a4a;color:#fff;border:1px solid #666;border-radius:6px;padding:5px 10px;cursor:pointer;font:13px sans-serif}' +
+      '.tm-pad-btn.primary{background:#2b6cb0}' +
+      '.tm-pad-nudge{background:#3a3a4a;color:#fff;border:1px solid #666;border-radius:5px;width:26px;height:26px;cursor:pointer;font:14px sans-serif}'
+    document.body.appendChild(style)
+    panel = document.createElement('div')
+    panel.className = 'tm-pad-editpanel'
+    panel.style.cssText = [
+      'position:fixed', 'left:50%', 'top:10px', 'transform:translateX(-50%)',
+      'z-index:100000003', 'background:rgba(20,20,30,0.92)', 'color:#fff',
+      'border:1px solid #555', 'border-radius:12px', 'padding:10px 14px',
+      'max-width:calc(100vw - 20px)', 'box-shadow:0 4px 20px rgba(0,0,0,0.5)',
+      'user-select:none', 'font:14px/1.5 sans-serif', 'touch-action:none'
+    ].join(';')
+    panel.innerHTML =
+      '<div class="tm-pad-title" style="font-weight:bold;margin-bottom:6px;cursor:move">键盘映射（拖动此框移动）</div>' +
+      '<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">' +
+      '<label>缩放 <input type="range" min="1" max="200" value="100" class="tm-pad-scale" style="width:90px"></label>' +
+      '<span class="tm-pad-scaleval">100%</span>' +
+      '<button class="tm-pad-btn" data-act="transparent">透明</button>' +
+      '<span class="tm-pad-vislabel" style="color:#ff9"></span>' +
+      '</div>' +
+      '<div style="display:flex;align-items:center;gap:6px;margin-top:8px;flex-wrap:wrap">' +
+      '<span>微调</span>' +
+      '<button class="tm-pad-nudge" data-d="up">↑</button>' +
+      '<button class="tm-pad-nudge" data-d="left">←</button>' +
+      '<button class="tm-pad-nudge" data-d="right">→</button>' +
+      '<button class="tm-pad-nudge" data-d="down">↓</button>' +
+      '</div>' +
+      '<div style="display:flex;align-items:center;gap:8px;margin-top:10px;flex-wrap:wrap">' +
+      '<button class="tm-pad-btn primary" data-act="save">保存并退出</button>' +
+      '<button class="tm-pad-btn" data-act="reset">恢复默认</button>' +
+      '<button class="tm-pad-btn" data-act="cancel">取消</button>' +
+      '</div>'
+    document.body.appendChild(panel)
+    var title = panel.querySelector('.tm-pad-title')
+    panel.addEventListener('pointerdown', function (ev) {
+      if (ev.target !== title) return
+      var cr = panel.getBoundingClientRect()
+      panelGrab = { sx: ev.clientX, sy: ev.clientY, ox: cr.left, oy: cr.top }
+    })
+    panel.addEventListener('pointermove', function (ev) {
+      if (!panelGrab) return
+      panel.style.transform = 'none'
+      panel.style.left = (panelGrab.ox + (ev.clientX - panelGrab.sx)) + 'px'
+      panel.style.top = (panelGrab.oy + (ev.clientY - panelGrab.sy)) + 'px'
+    })
+    panel.addEventListener('pointerup', function () { panelGrab = null })
+    panel.addEventListener('pointercancel', function () { panelGrab = null })
+
+    var slider = panel.querySelector('.tm-pad-scale')
+    slider.addEventListener('input', function () {
+      if (!selectedId) return
+      var c = ensureButtonCfg(selectedId)
+      if (c.x == null && c.y == null) { var r = getElById(selectedId).getBoundingClientRect(); c.x = r.left; c.y = r.top }
+      c.scale = Number(slider.value) / 100
+      refreshEditConfig()
+      setSelected(selectedId)
+    })
+    panel.querySelectorAll('.tm-pad-nudge').forEach(function (b) {
+      b.addEventListener('click', function () {
+        if (!selectedId) return
+        var c = ensureButtonCfg(selectedId)
+        var el = getElById(selectedId)
+        var pr = el.getBoundingClientRect()
+        c.x = pr.left
+        c.y = pr.top
+        var d = b.getAttribute('data-d')
+        if (d === 'up') c.y -= NUDGE
+        else if (d === 'down') c.y += NUDGE
+        else if (d === 'left') c.x -= NUDGE
+        else if (d === 'right') c.x += NUDGE
+        refreshEditConfig()
+        setSelected(selectedId)
+      })
+    })
+    panel.querySelector('[data-act="transparent"]').addEventListener('click', function () {
+      if (!selectedId) return
+      var c = ensureButtonCfg(selectedId)
+      c.visible = false
+      refreshEditConfig()
+      setSelected(selectedId)
+    })
+    panel.querySelector('[data-act="save"]').addEventListener('click', function () { saveAndExit(false) })
+    panel.querySelector('[data-act="reset"]').addEventListener('click', function () {
+      collectEditable()
+      allEditableEls.forEach(function (entry) {
+        var meta = entry.el.__pad || {}
+        if (editConfig.buttons) delete editConfig.buttons[meta.id]
+      })
+      refreshEditConfig()
+      if (selectedId) setSelected(selectedId)
+      layout()
+    })
+    panel.querySelector('[data-act="cancel"]').addEventListener('click', function () {
+      editConfig = padConfig ? JSON.parse(JSON.stringify(padConfig)) : { buttons: {} }
+      exitEdit()
+      layout()
+    })
+  }
+
+  function getElById(id) {
+    for (var i = 0; i < allEditableEls.length; i++) if (allEditableEls[i].id === id) return allEditableEls[i].el
+    return null
+  }
+
+  function enterEdit() {
+    if (editMode) return
+    editMode = true
+    editConfig = padConfig ? JSON.parse(JSON.stringify(padConfig)) : { buttons: {} }
+    overlay = document.createElement('div')
+    overlay.style.cssText = 'position:fixed;left:0;top:0;width:100%;height:100%;' +
+      'background:rgba(0,0,0,0.65);z-index:100000000;touch-action:none'
+    document.body.appendChild(overlay)
+    buildPanel()
+    // 收集全部按钮并打上可编辑类
+    collectEditable()
+    allEditableEls.forEach(function (entry) {
+      var el = entry.el
+      el.__group = qwzxEls.indexOf(el) >= 0 ? 'qwzx' : 'action'
+      el.classList.add('tm-pad-editable')
+      el.style.pointerEvents = 'auto'
+    })
+    // 从已保存配置恢复工作副本位置（若首次编辑按默认布局落位）
+    collectEditable()
+    allEditableEls.forEach(function (entry) {
+      var meta = entry.el.__pad || {}
+      var c = editConfig.buttons[meta.id]
+      if (!c || c.x == null || c.y == null) {
+        var r = entry.el.getBoundingClientRect()
+        editConfig.buttons[meta.id] = c || defaultButtonFor(meta.id)
+        editConfig.buttons[meta.id].x = r.left
+        editConfig.buttons[meta.id].y = r.top
+      }
+    })
+    refreshEditConfig()
+    // 选中第一个可见按钮方便直接调整
+    var first = allEditableEls.filter(function (e) { var c = editConfig.buttons[e.id]; return !c || c.visible !== false })[0]
+    if (first) setSelected(first.id)
+    attachEditDrag()
+  }
+
+  function attachEditDrag() {
+    var target = null
+    var drag = null
+    function onDown(ev, el) {
+      ev.stopPropagation()
+      ev.preventDefault()
+      var meta = el.__pad || {}
+      setSelected(meta.id)
+      var c = ensureButtonCfg(meta.id)
+      c.visible = true
+      var r = el.getBoundingClientRect()
+      c.x = r.left
+      c.y = r.top
+      drag = { id: meta.id, ox: ev.clientX, oy: ev.clientY, bx: c.x, by: c.y, moved: false }
+    }
+    function onMove(ev) {
+      if (!drag) return
+      var dx = ev.clientX - drag.ox
+      var dy = ev.clientY - drag.oy
+      if (!drag.moved && Math.abs(dx) + Math.abs(dy) < 8) return
+      drag.moved = true
+      var c = ensureButtonCfg(drag.id)
+      c.x = drag.bx + dx
+      c.y = drag.by + dy
+      refreshEditConfig()
+    }
+    function onUp() { drag = null }
+
+    allEditableEls.forEach(function (entry) {
+      entry.el.removeEventListener('pointerdown', entry._pd)
+      entry.el.removeEventListener('pointermove', entry._pm)
+      entry.el.removeEventListener('pointerup', entry._pu)
+      entry._pd = function (ev) { onDown(ev, entry.el) }
+      entry._pm = onMove
+      entry._pu = onUp
+      entry.el.addEventListener('pointerdown', entry._pd)
+      entry.el.addEventListener('pointermove', entry._pm)
+      entry.el.addEventListener('pointerup', entry._pu)
+    })
+    if (overlay) {
+      overlay.addEventListener('pointerup', onUp)
+      overlay.addEventListener('pointercancel', onUp)
+    }
+  }
+
+  function exitEdit() {
+    editMode = false
+    allEditableEls.forEach(function (entry) {
+      if (entry.el._pd) entry.el.removeEventListener('pointerdown', entry._pd)
+      if (entry.el._pm) entry.el.removeEventListener('pointermove', entry._pm)
+      if (entry.el._pu) entry.el.removeEventListener('pointerup', entry._pu)
+      delete entry.el._pd
+      delete entry.el._pm
+      delete entry.el._pu
+      entry.el.classList.remove('tm-pad-editable')
+      entry.el.style.outline = ''
+    })
+    if (overlay && overlay.parentNode) overlay.parentNode.removeChild(overlay)
+    overlay = null
+    if (panel && panel.parentNode) panel.parentNode.removeChild(panel)
+    panel = null
+    panelGrab = null
+    selectedId = null
+  }
+
+  // 恢复默认布局：清空配置并持久化（可在编辑面板或从悬浮球触发）
+  function resetToDefaults() {
+    padConfig = { buttons: {} }
+    if (editMode) editConfig = { buttons: {} }
+    try {
+      if (window && window.TyranorTouchPadNative && window.TyranorTouchPadNative.saveConfig) {
+        window.TyranorTouchPadNative.saveConfig('{}')
+      }
+    } catch (e) { /* 忽略 */ }
+    if (editMode) {
+      collectEditable()
+      refreshEditConfig()
+      if (selectedId) setSelected(selectedId)
+    }
+    layout()
+  }
+
+  // 暴露 API 供修改器悬浮球（__rpgmaker_mod_ui.js）与外部调用
+  window.__touchPad = {
+    enterEdit: enterEdit,
+    exitEdit: exitEdit,
+    saveAndExit: saveAndExit,
+    resetToDefaults: resetToDefaults,
+    isEditMode: function () { return editMode },
+    getConfig: function () { return padConfig ? JSON.stringify(padConfig) : '' }
+  }
+
   layout()
   window.addEventListener('resize', layout)
   // 旋转后画布矩形可能滞后于视口变化，延迟一帧再排

--- a/engine/src/main/assets/__touch_pad.js
+++ b/engine/src/main/assets/__touch_pad.js
@@ -445,10 +445,10 @@ window.addEventListener('load', () => {
   }
   const setEventStart = (e, keyCodes) => {
     const press = (evt) => {
-      // 编辑模式也要拦截事件冒泡到游戏（游戏在 document 监听），仅跳过按键派发
+      // 编辑/预览模式也要拦截事件冒泡到游戏（游戏在 document 监听），仅跳过按键派发
       evt.stopPropagation()
       evt.preventDefault()
-      if (editMode) return
+      if (editMode || previewMode) return
       setKeyDownColor(e)
       keyCodes.forEach(keyCode => {
         startKeyEvent(e, keyCode, 'keydown')
@@ -470,7 +470,7 @@ window.addEventListener('load', () => {
     const release = (evt) => {
       evt.stopPropagation()
       evt.preventDefault()
-      if (editMode) return
+      if (editMode || previewMode) return
       setKeyUpColor(e)
       keyCodes.forEach(keyCode => {
         startKeyEvent(e, keyCode, 'keyup')
@@ -530,20 +530,20 @@ window.addEventListener('load', () => {
     el.addEventListener('touchstart', (evt) => {
       evt.stopPropagation()
       evt.preventDefault()
-      if (editMode) return
+      if (editMode || previewMode) return
       setKeyDownColor(el)
     })
     el.addEventListener('mousedown', (evt) => {
       evt.stopPropagation()
       evt.preventDefault()
-      if (editMode) return
+      if (editMode || previewMode) return
       setKeyDownColor(el)
     })
     setEventMove(el)
     const release = (evt) => {
       evt.stopPropagation()
       evt.preventDefault()
-      if (editMode) return
+      if (editMode || previewMode) return
       setKeyUpColor(el)
       onRelease()
     }
@@ -591,21 +591,21 @@ window.addEventListener('load', () => {
   joyStickStage.addEventListener('touchstart', (evt) => {
     evt.stopPropagation()
     evt.preventDefault()
-    if (editMode) return
+    if (editMode || previewMode) return
     const touch = evt.targetTouches[0]
     joyStart(touch.clientX, touch.clientY)
   })
   joyStickStage.addEventListener('touchmove', (evt) => {
     evt.stopPropagation()
     evt.preventDefault()
-    if (editMode) return
+    if (editMode || previewMode) return
     const touch = evt.targetTouches[0]
     joyMove(touch.clientX, touch.clientY)
   })
   joyStickStage.addEventListener('touchend', (evt) => {
     evt.stopPropagation()
     evt.preventDefault()
-    if (editMode) return
+    if (editMode || previewMode) return
     joyEnd()
   })
   // 虚拟鼠标拖拽摇杆：光标按下后跟随 mousemove
@@ -613,18 +613,18 @@ window.addEventListener('load', () => {
   joyStickStage.addEventListener('mousedown', (evt) => {
     evt.stopPropagation()
     evt.preventDefault()
-    if (editMode) return
+    if (editMode || previewMode) return
     joyMouseDown = true
     joyStart(evt.clientX, evt.clientY)
   })
   window.addEventListener('mousemove', (evt) => {
-    if (editMode) return
+    if (editMode || previewMode) return
     if (!joyMouseDown) return
     evt.stopPropagation()
     joyMove(evt.clientX, evt.clientY)
   })
   window.addEventListener('mouseup', (evt) => {
-    if (editMode) return
+    if (editMode || previewMode) return
     if (!joyMouseDown) return
     evt.stopPropagation()
     joyMouseDown = false
@@ -704,7 +704,12 @@ window.addEventListener('load', () => {
   var EDIT_INPUT_EVENTS = ['touchstart', 'touchmove', 'touchend', 'mousedown', 'mousemove', 'mouseup', 'pointerdown', 'pointermove', 'pointerup', 'click', 'contextmenu']
   function installEditBlock(el) {
     EDIT_INPUT_EVENTS.forEach(function (name) {
-      var fn = function (ev) { ev.stopPropagation(); ev.preventDefault() }
+      var fn = function (ev) {
+        ev.stopPropagation()
+        // 允许输入框聚焦/输入，不 preventDefault
+        var t = ev.target
+        if (!t || (t.tagName !== 'INPUT' && t.tagName !== 'TEXTAREA')) ev.preventDefault()
+      }
       el.addEventListener(name, fn)
       editBlockers.push({ el: el, name: name, fn: fn })
     })
@@ -922,6 +927,7 @@ window.addEventListener('load', () => {
       'user-select:none', 'font:14px/1.5 sans-serif', 'touch-action:none'
     ].join(';')
     panel.innerHTML =
+      '<div data-act="mainview">' +
       // 标题 + 缩放（滑杆 + +/- 按钮）+ 透明
       '<div class="tm-pad-title" style="font-weight:bold;margin-bottom:8px;cursor:move">键盘映射 · 拖动控制或按钮调整（拖动框可移动）</div>' +
       '<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:8px">' +
@@ -953,8 +959,23 @@ window.addEventListener('load', () => {
       '</div>' +
       '<div style="display:flex;align-items:center;gap:8px;margin-top:10px;flex-wrap:wrap">' +
       '<button class="tm-pad-btn primary" data-act="save">保存并退出</button>' +
+      '<button class="tm-pad-btn" data-act="presets">预设</button>' +
       '<button class="tm-pad-btn" data-act="reset">恢复默认</button>' +
       '<button class="tm-pad-btn" data-act="cancel">取消</button>' +
+      '</div>' +
+      '</div>' +
+      // 预设管理视图（默认隐藏）
+      '<div data-act="presetview" style="display:none;margin-top:4px">' +
+      '<div style="display:flex;align-items:center;justify-content:space-between">' +
+      '<strong>预设管理（最多 10 个）</strong>' +
+      '<button class="tm-pad-btn" data-act="presetback">返回</button>' +
+      '</div>' +
+      '<div data-act="presetlist" style="margin-top:6px;max-height:38vh;overflow-y:auto"></div>' +
+      '<div style="display:flex;gap:8px;margin-top:8px;align-items:center">' +
+      '<input class="tm-pad-input" data-act="presetname" maxlength="12" placeholder="预设名（≤12 字）" style="flex:1;min-width:0;background:#2a2a38;color:#fff;border:1px solid #555;border-radius:6px;padding:8px;font:14px sans-serif;user-select:text">' +
+      '<button class="tm-pad-btn primary" data-act="presetsave">保存为新预设</button>' +
+      '</div>' +
+      '<div data-act="presetmsg" style="color:#7fd0ff;margin-top:4px;min-height:18px"></div>' +
       '</div>'
     document.body.appendChild(panel)
     var title = panel.querySelector('.tm-pad-title')
@@ -1033,6 +1054,10 @@ window.addEventListener('load', () => {
       exitEdit()
       layout()
     })
+    // 预设
+    bindTap(panel.querySelector('[data-act="presets"]'), function () { showPresetView() })
+    bindTap(panel.querySelector('[data-act="presetback"]'), function () { showMainView() })
+    bindTap(panel.querySelector('[data-act="presetsave"]'), function () { onPresetSaveClick() })
   }
 
   function getElById(id) {
@@ -1042,6 +1067,8 @@ window.addEventListener('load', () => {
 
   function enterEdit() {
     if (editMode) return
+    if (previewMode) exitPreview()
+    setFabHidden(true)
     editMode = true
     editConfig = padConfig ? JSON.parse(JSON.stringify(padConfig)) : { buttons: {} }
     overlay = document.createElement('div')
@@ -1142,6 +1169,8 @@ window.addEventListener('load', () => {
   function exitEdit() {
     editMode = false
     removeEditBlock()
+    blurPresetInput()
+    setFabHidden(false)
     collectEditable()
     allEditableEls.forEach(function (entry) {
       unbindDrag(entry.el)
@@ -1177,6 +1206,277 @@ window.addEventListener('load', () => {
     layout()
   }
 
+  // ================= 预设（保存/载入/重命名/删除，最多 10 个，名称 ≤12 字） =================
+  // 用 null-prototype 对象，避免用户命名 __proto__/constructor 污染原型
+  var presets = Object.create(null)
+  var presetMode = false    // 是否在预设管理视图
+  var presetRename = null   // 正在重命名的旧名称
+  var PRESET_MAX = 10
+  // 预览模式（只读查看预设布局）
+  var previewMode = false
+  var previewRestore = null
+  var previewBanner = null
+  var previewOverlay = null
+
+  function sanitizeName(name) {
+    return String(name || '').replace(/\s+/g, ' ').trim().slice(0, 12)
+  }
+  function loadPresetsRaw() {
+    presets = Object.create(null)
+    try {
+      if (window && window.TyranorTouchPadNative && window.TyranorTouchPadNative.getPresets) {
+        var raw = window.TyranorTouchPadNative.getPresets()
+        if (raw) {
+          var parsed = JSON.parse(raw)
+          if (parsed && typeof parsed === 'object') {
+            Object.keys(parsed).forEach(function (k) { presets[k] = parsed[k] })
+          }
+        }
+      }
+    } catch (e) { /* 忽略 */ }
+    return presets
+  }
+  function persistPresets() {
+    try {
+      if (window && window.TyranorTouchPadNative && window.TyranorTouchPadNative.savePresets) {
+        window.TyranorTouchPadNative.savePresets(JSON.stringify(presets))
+      }
+    } catch (e) { /* 忽略 */ }
+  }
+  function currentLayoutConfig() {
+    var cfg = (editMode && editConfig) ? editConfig : padConfig
+    return cfg ? JSON.parse(JSON.stringify(cfg)) : { buttons: {} }
+  }
+  function savePreset(name) {
+    name = sanitizeName(name)
+    if (!name) return { ok: false, msg: '预设名不能为空' }
+    var names = Object.keys(presets)
+    if (!(name in presets) && names.length >= PRESET_MAX) {
+      return { ok: false, msg: '预设已达上限（' + PRESET_MAX + ' 个），请先删除或重命名' }
+    }
+    presets[name] = currentLayoutConfig()
+    persistPresets()
+    return { ok: true, msg: '已保存预设「' + name + '」' }
+  }
+  function loadPreset(name) {
+    if (!(name in presets)) return { ok: false, msg: '预设「' + name + '」不存在' }
+    var cfg = JSON.parse(JSON.stringify(presets[name]))
+    if (editMode) {
+      // 编辑中仅替换工作副本，由「保存并退出」统一持久化，取消可回退
+      editConfig = JSON.parse(JSON.stringify(cfg))
+      refreshEditConfig()
+    } else {
+      padConfig = cfg
+      try {
+        if (window && window.TyranorTouchPadNative && window.TyranorTouchPadNative.saveConfig) {
+          window.TyranorTouchPadNative.saveConfig(JSON.stringify(cfg))
+        }
+      } catch (e) { /* 忽略 */ }
+      layout()
+    }
+    return { ok: true, msg: '已载入预设「' + name + '」' }
+  }
+  function renamePreset(oldName, newName) {
+    oldName = sanitizeName(oldName)
+    newName = sanitizeName(newName)
+    if (!(oldName in presets)) return { ok: false, msg: '预设不存在' }
+    if (!newName) return { ok: false, msg: '预设名不能为空' }
+    if (newName !== oldName && newName in presets) return { ok: false, msg: '预设名「' + newName + '」已存在' }
+    if (newName !== oldName) {
+      presets[newName] = presets[oldName]
+      delete presets[oldName]
+    }
+    persistPresets()
+    return { ok: true, msg: '已重命名为「' + newName + '」' }
+  }
+  function deletePreset(name) {
+    name = sanitizeName(name)
+    if (!(name in presets)) return { ok: false, msg: '预设不存在' }
+    delete presets[name]
+    persistPresets()
+    return { ok: true, msg: '已删除「' + name + '」' }
+  }
+
+  // ---------- 预设管理 UI ----------
+  function setPresetMsg(text) {
+    var m = panel && panel.querySelector('[data-act="presetmsg"]')
+    if (m) m.textContent = text || ''
+  }
+  function showMainView() {
+    presetMode = false
+    presetRename = null
+    blurPresetInput()
+    var main = panel && panel.querySelector('[data-act="mainview"]')
+    var pv = panel && panel.querySelector('[data-act="presetview"]')
+    if (main) main.style.display = ''
+    if (pv) pv.style.display = 'none'
+  }
+  function showPresetView() {
+    presetMode = true
+    presetRename = null
+    blurPresetInput()
+    var main = panel && panel.querySelector('[data-act="mainview"]')
+    var pv = panel && panel.querySelector('[data-act="presetview"]')
+    if (main) main.style.display = 'none'
+    if (pv) pv.style.display = 'block'
+    var input = panel && panel.querySelector('[data-act="presetname"]')
+    if (input) input.value = ''
+    var saveBtn = panel && panel.querySelector('[data-act="presetsave"]')
+    if (saveBtn) saveBtn.textContent = '保存为新预设'
+    setPresetMsg('')
+    loadPresetsRaw()
+    renderPresetList()
+  }
+  function renderPresetList() {
+    var list = panel && panel.querySelector('[data-act="presetlist"]')
+    if (!list) return
+    list.innerHTML = ''
+    var names = Object.keys(presets).sort()
+    if (names.length === 0) {
+      list.innerHTML = '<div style="opacity:0.6;padding:6px 0">暂无预设。输入名称可保存当前布局。</div>'
+      return
+    }
+    names.forEach(function (name) {
+      var row = document.createElement('div')
+      row.style.cssText = 'display:flex;align-items:center;gap:6px;padding:6px 0;border-bottom:1px solid #333'
+      var label = document.createElement('span')
+      label.style.cssText = 'flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap'
+      label.textContent = name
+      row.appendChild(label)
+      var load = document.createElement('button')
+      var rn = document.createElement('button')
+      var del = document.createElement('button')
+      load.className = rn.className = del.className = 'tm-pad-btn'
+      load.textContent = '载入'
+      rn.textContent = '重命名'
+      del.textContent = '删除'
+      load.style.cssText = rn.style.cssText = del.style.cssText = 'padding:3px 8px;font:12px sans-serif'
+      row.appendChild(load)
+      row.appendChild(rn)
+      row.appendChild(del)
+      list.appendChild(row)
+      bindTap(load, function () { applyPresetAction('load', name) })
+      bindTap(rn, function () { startPresetRename(name) })
+      bindTap(del, function () { applyPresetAction('delete', name) })
+    })
+  }
+  function startPresetRename(name) {
+    presetRename = name
+    var input = panel && panel.querySelector('[data-act="presetname"]')
+    if (input) input.value = name
+    var saveBtn = panel && panel.querySelector('[data-act="presetsave"]')
+    if (saveBtn) saveBtn.textContent = '重命名'
+    setPresetMsg('正在重命名「' + name + '」')
+  }
+  function onPresetSaveClick() {
+    var input = panel && panel.querySelector('[data-act="presetname"]')
+    var name = sanitizeName(input ? input.value : '')
+    if (!name) { setPresetMsg('请输入预设名'); return }
+    var res = presetRename ? renamePreset(presetRename, name) : savePreset(name)
+    setPresetMsg(res.msg)
+    blurPresetInput()
+    if (res.ok) {
+      presetRename = null
+      if (input) input.value = ''
+      var saveBtn = panel && panel.querySelector('[data-act="presetsave"]')
+      if (saveBtn) saveBtn.textContent = '保存为新预设'
+      renderPresetList()
+    }
+  }
+  function applyPresetAction(action, name) {
+    var res
+    if (action === 'load') {
+      res = loadPreset(name)
+      if (res.ok) { showMainView(); return }
+    } else if (action === 'delete') {
+      res = deletePreset(name)
+    }
+    setPresetMsg(res.msg)
+    blurPresetInput()
+    renderPresetList()
+  }
+
+  // 隐藏/恢复修改器悬浮球（编辑/预览时不可点开，保持模态）
+  function setFabHidden(hidden) {
+    try {
+      var fab = document.getElementById('tyranor-mod-launcher')
+      if (fab) fab.style.display = hidden ? 'none' : ''
+    } catch (e) { /* 忽略 */ }
+  }
+
+  // 强制收起软键盘（编辑面板 preventDefault 会阻止点击外部自动失焦；
+  // 仅 blur 在部分 WebView 不可靠，配合 readonly 技巧强制收起）
+  function blurPresetInput() {
+    var inp = panel && panel.querySelector('[data-act="presetname"]')
+    if (!inp) return
+    try { inp.setAttribute('readonly', 'readonly') } catch (e) {}
+    if (inp.blur) inp.blur()
+    setTimeout(function () {
+      try { inp.removeAttribute('readonly') } catch (e) {}
+    }, 150)
+  }
+
+  // ---------- 预设预览（只读，只能退出） ----------
+  function previewPreset(name) {
+    name = sanitizeName(name)
+    loadPresetsRaw()
+    if (!(name in presets)) return { ok: false, msg: '预设「' + name + '」不存在' }
+    if (editMode) return { ok: false, msg: '请先退出键盘映射再预览' }
+    if (!previewMode) {
+      previewMode = true
+      setFabHidden(true)
+      previewRestore = padConfig
+      previewOverlay = document.createElement('div')
+      previewOverlay.style.cssText = 'position:fixed;left:0;top:0;width:100%;height:100%;' +
+        'background:rgba(0,0,0,0.25);z-index:100000000;touch-action:none'
+      document.body.appendChild(previewOverlay)
+      previewBanner = document.createElement('div')
+      previewBanner.className = 'tm-pad-preview-banner'
+      previewBanner.style.cssText = [
+        'position:fixed', 'left:50%', 'top:14px', 'transform:translateX(-50%)',
+        'z-index:100000010', 'background:rgba(20,20,30,0.95)', 'color:#fff',
+        'border:1px solid #4a9eff', 'border-radius:12px', 'padding:8px 14px',
+        'display:flex', 'align-items:center', 'gap:10px',
+        'font:14px/1.4 sans-serif', 'box-shadow:0 4px 20px rgba(0,0,0,0.5)',
+        'user-select:none', 'touch-action:none', 'max-width:92vw'
+      ].join(';')
+      var label = document.createElement('span')
+      label.className = 'tm-pad-preview-name'
+      label.style.cssText = 'white-space:nowrap;overflow:hidden;text-overflow:ellipsis'
+      label.textContent = '预览：' + name
+      previewBanner.appendChild(label)
+      var btn = document.createElement('button')
+      btn.className = 'tm-pad-btn primary'
+      btn.textContent = '退出预览'
+      btn.style.cssText = 'padding:6px 12px;font:13px sans-serif'
+      previewBanner.appendChild(btn)
+      document.body.appendChild(previewBanner)
+      bindTap(btn, function () { exitPreview() })
+      removeEditBlock()
+      installEditBlock(previewOverlay)
+      installEditBlock(previewBanner)
+    } else {
+      var nm = previewBanner && previewBanner.querySelector('.tm-pad-preview-name')
+      if (nm) nm.textContent = '预览：' + name
+    }
+    padConfig = JSON.parse(JSON.stringify(presets[name]))
+    layout()
+    return { ok: true, msg: '' }
+  }
+  function exitPreview() {
+    if (!previewMode) return
+    previewMode = false
+    if (previewOverlay && previewOverlay.parentNode) previewOverlay.parentNode.removeChild(previewOverlay)
+    previewOverlay = null
+    if (previewBanner && previewBanner.parentNode) previewBanner.parentNode.removeChild(previewBanner)
+    previewBanner = null
+    removeEditBlock()
+    setFabHidden(false)
+    padConfig = previewRestore
+    previewRestore = null
+    layout()
+  }
+
   // 暴露 API 供修改器悬浮球（__rpgmaker_mod_ui.js）与外部调用
   window.__touchPad = {
     enterEdit: enterEdit,
@@ -1184,9 +1484,18 @@ window.addEventListener('load', () => {
     saveAndExit: saveAndExit,
     resetToDefaults: resetToDefaults,
     isEditMode: function () { return editMode },
-    getConfig: function () { return padConfig ? JSON.stringify(padConfig) : '' }
+    getConfig: function () { return padConfig ? JSON.stringify(padConfig) : '' },
+    savePreset: savePreset,
+    loadPreset: loadPreset,
+    renamePreset: renamePreset,
+    deletePreset: deletePreset,
+    listPresets: function () { loadPresetsRaw(); return Object.keys(presets) },
+    previewPreset: previewPreset,
+    exitPreview: exitPreview,
+    isPreview: function () { return previewMode }
   }
 
+  loadPresetsRaw()
   layout()
   window.addEventListener('resize', function () {
     if (editMode) refreshEditConfig()

--- a/engine/src/main/assets/__touch_pad.js
+++ b/engine/src/main/assets/__touch_pad.js
@@ -29,12 +29,18 @@ window.addEventListener('load', () => {
   const actionsElement = document.createElement('div')
   const keySwitchElement = document.createElement('div')
   keySwitchElement.innerText = isKeysShown ? 'Hide' : 'Show'
+  keySwitchElement.__pad = { id: 'btn.hide', text: 'Hide/Show' }
   const joyStickSwitchElement = document.createElement('div')
   joyStickSwitchElement.innerText = useJoyStick ? 'Button' : 'Stick'
+  joyStickSwitchElement.__pad = { id: 'btn.stick', text: 'Button/Stick' }
   const dir8SwitchElement = document.createElement('div')
   dir8SwitchElement.innerText = useDir8 ? '4 Dir' : '8 Dir'
+  dir8SwitchElement.__pad = { id: 'btn.dir8', text: '4/8 Dir' }
   const udlrElement = document.createElement('div')
+  udlrElement.__pad = { id: 'dpad', text: '方向键' }
   const qwzxElement = document.createElement('div')
+  qwzxElement.__pad = { id: 'qwzx', text: 'QWZX 键组' }
+  joyStickStage.__pad = { id: 'joystick', text: '摇杆' }
   document.body.appendChild(actionsElement)
   actionsElement.appendChild(keySwitchElement)
   actionsElement.appendChild(joyStickSwitchElement)
@@ -46,10 +52,25 @@ window.addEventListener('load', () => {
 
   // issue #30：自定义布局。window.__touchPadConfig 由 TyranoActivity 按游戏注入：
   // { buttons: { <id>: { x, y, scale, visible } } }
+  // 坐标采用「归一化」（相对视口 0..1），横竖屏切换后按比例重映射，位置不漂移。
+  const vw = () => window.innerWidth || 1
+  const vh = () => window.innerHeight || 1
   let padConfig = null
   try {
     const raw = window.__touchPadConfig
-    if (raw && typeof raw === 'object' && raw.buttons) padConfig = raw
+    if (raw && typeof raw === 'object' && raw.buttons) {
+      // 一次性迁移：旧配置存的是视口像素（x>1），转成归一化
+      const mig = raw.buttons
+      const needsMig = Object.keys(mig).some(function (k) { var b = mig[k]; return b && (b.x > 1 || b.y > 1) })
+      if (needsMig) {
+        Object.keys(mig).forEach(function (k) {
+          var b = mig[k]
+          if (b && b.x != null) b.x = b.x / vw()
+          if (b && b.y != null) b.y = b.y / vh()
+        })
+      }
+      padConfig = raw
+    }
   } catch (e) { /* 忽略坏配置，回退默认 */ }
   const btnScale = (custom) => {
     const s = custom && custom.scale != null ? Number(custom.scale) : 1
@@ -223,6 +244,44 @@ window.addEventListener('load', () => {
 
   let actionEls = []
   const qwzxEls = []
+  // 编辑模式把「透明」渲染为醒目的蓝色占位（仍可选中/调整）；普通模式才真正隐藏。
+  // 用 CSS 类实现淡显，避免覆盖 btnStyle 的内联背景（否则普通按钮失去粉色）。
+  function applyFade(el, custom) {
+    var inv = custom && custom.visible === false
+    if (editMode && inv) {
+      el.style.display = 'block'
+      el.classList.add('tm-pad-faded')
+    } else {
+      el.classList.remove('tm-pad-faded')
+      if (inv) el.style.display = 'none'
+      else el.style.display = el.__disp || ''
+    }
+  }
+  // 中心定位统一入口：container 为元素定位参考容器（无则视口）。
+  // 用 offsetWidth/offsetHeight（布局尺寸，不受 transform scale 影响）作为未缩放盒，
+  // 使视觉中心恒定落在目标点，缩放/拖拽/微调全程不漂移。
+  // custom.x/y 为归一化坐标（0..1 相对视口），此处换算回像素。
+  function placeAtCenter(el, custom, scale, container) {
+    var baseTransform = el.__baseTransform || ''
+    if (custom && custom.x != null && custom.y != null) {
+      var w = el.offsetWidth || 0
+      var h = el.offsetHeight || 0
+      var cl = container ? container.getBoundingClientRect().left : 0
+      var ct = container ? container.getBoundingClientRect().top : 0
+      el.style.transform = scale === 1 ? '' : 'scale(' + scale + ')'
+      el.style.transformOrigin = 'center'
+      el.style.left = (custom.x * vw() - w / 2 - cl) + 'px'
+      el.style.top = (custom.y * vh() - h / 2 - ct) + 'px'
+      el.style.right = 'auto'
+    } else {
+      el.style.transform = (scale === 1 ? '' : 'scale(' + scale + ')') + baseTransform
+      el.style.transformOrigin = 'center'
+      // 恢复默认定位（qwzx 用百分比；自定义清除后必须还原，否则残留在旧像素位）
+      if (el.__baseLeft != null) el.style.left = el.__baseLeft
+      if (el.__baseTop != null) el.style.top = el.__baseTop
+      if (el.__baseLeft != null || el.__baseTop != null) el.style.right = ''
+    }
+  }
   function layout() {
     const g = gameRect()
     const r = g.rect
@@ -231,48 +290,78 @@ window.addEventListener('load', () => {
     joyStickR = joyStickSR * 0.4
     joyStickCX = r.left + joyStickSR + allMargin + lrMargin
     joyStickCY = r.top + r.height - joyStickSR - allMargin
+    const activeCfg = (editMode ? editConfig : padConfig)
+    // 编辑模式忽略「隐藏键盘」，让所有控件可选中/调整
+    const showKeys = editMode || isKeysShown
     const switchTop = (i) => `${r.top + allMargin + i * (padSize * 0.3 + 5)}px`
-    Object.assign(keySwitchElement.style, {
-      ...btnStyle,
-      width: switchSize(),
-      height: switchSize(),
-      lineHeight: switchSize(),
-      borderRadius: '50em',
-      left: `${r.left + allMargin}px`,
-      top: switchTop(0),
-      display: 'block'
+    const switches = [
+      { el: keySwitchElement, id: 'btn.hide', top: switchTop(0), disp: 'block' },
+      { el: joyStickSwitchElement, id: 'btn.stick', top: switchTop(1), disp: showKeys ? 'block' : 'none' },
+      { el: dir8SwitchElement, id: 'btn.dir8', top: switchTop(2), disp: showKeys ? 'block' : 'none' }
+    ]
+    switches.forEach(function (sw) {
+      const custom = activeCfg && activeCfg.buttons && activeCfg.buttons[sw.id]
+      const scale = btnScale(custom)
+      Object.assign(sw.el.style, {
+        ...btnStyle,
+        width: switchSize(),
+        height: switchSize(),
+        lineHeight: switchSize(),
+        borderRadius: '50em'
+      })
+      sw.el.style.left = (custom && custom.x != null ? 'auto' : `${r.left + allMargin}px`)
+      sw.el.style.top = (custom && custom.y != null ? 'auto' : sw.top)
+      sw.el.__disp = sw.disp
+      applyFade(sw.el, custom)
+      placeAtCenter(sw.el, custom, scale, null)
     })
-    Object.assign(joyStickSwitchElement.style, {
-      ...btnStyle,
-      width: switchSize(),
-      height: switchSize(),
-      lineHeight: switchSize(),
-      borderRadius: '50em',
-      left: `${r.left + allMargin}px`,
-      top: switchTop(1),
-      display: isKeysShown ? 'block' : 'none'
-    })
-    Object.assign(dir8SwitchElement.style, {
-      ...btnStyle,
-      width: switchSize(),
-      height: switchSize(),
-      lineHeight: switchSize(),
-      borderRadius: '50em',
-      left: `${r.left + allMargin}px`,
-      top: switchTop(2),
-      display: isKeysShown ? 'block' : 'none'
-    })
-    Object.assign(joyStickStage.style, {
-      ...commonStyle,
-      boxShadow: '0 0 10px 0 rgba(255,255,255,0.5)',
-      width: `${padSize}px`,
-      height: `${padSize}px`,
-      transform: 'translate(0%,-100%)',
-      borderRadius: '50em',
-      left: `${r.left + allMargin + lrMargin}px`,
-      top: `${joyStickCY + joyStickSR}px`,
-      display: useJoyStick && isKeysShown ? 'block' : 'none'
-    })
+    // 摇杆圆盘 / 方向键圆盘（可自定义，二者同一位置，useJoyStick 决定显示谁）
+    const applyStage = function (el, id, active) {
+      const custom = activeCfg && activeCfg.buttons && activeCfg.buttons[id]
+      const scale = btnScale(custom)
+      Object.assign(el.style, {
+        ...commonStyle,
+        boxShadow: '0 0 10px 0 rgba(255,255,255,0.5)',
+        width: `${padSize}px`,
+        height: `${padSize}px`,
+        borderRadius: '50em'
+      })
+      el.__disp = active ? 'block' : 'none'
+      if (editMode) {
+        // 编辑模式：当前激活的实心显示，另一个以灰色虚线 ghost 占位（仍可选中/调整）
+        el.style.display = 'block'
+        el.classList.remove('tm-pad-faded')
+        if (!active) {
+          el.style.opacity = '0.4'
+          el.style.outline = '2px dashed rgba(150,150,160,0.8)'
+        } else {
+          el.style.opacity = ''
+          el.style.outline = ''
+          applyFade(el, custom)
+        }
+      } else {
+        el.style.opacity = ''
+        el.style.outline = ''
+        applyFade(el, custom)
+      }
+      // 自定义时用新中心定位；否则按默认锚点
+      if (custom && custom.x != null && custom.y != null) {
+        placeAtCenter(el, custom, scale, null)
+      } else {
+        el.style.transform = 'translate(0%,-100%)'
+        el.style.left = `${r.left + allMargin + lrMargin}px`
+        el.style.top = `${joyStickCY + joyStickSR}px`
+        el.style.transformOrigin = 'center'
+        if (scale !== 1) el.style.transform = 'translate(0%,-100%) scale(' + scale + ')'
+      }
+      if (id === 'joystick' && custom && custom.x != null && custom.y != null) {
+        // 摇杆方向判定中心跟随新位置（归一化转像素）
+        joyStickCX = custom.x * vw()
+        joyStickCY = custom.y * vh()
+      }
+    }
+    applyStage(joyStickStage, 'joystick', useJoyStick && isKeysShown)
+    applyStage(udlrElement, 'dpad', !useJoyStick && isKeysShown)
     Object.assign(joyStick.style, {
       ...btnStyle,
       marginLeft: `${joyStickSR - joyStickR}px`,
@@ -281,79 +370,47 @@ window.addEventListener('load', () => {
       height: `${2 * joyStickR}px`,
       borderRadius: '50em'
     })
-    Object.assign(udlrElement.style, {
-      ...commonStyle,
-      boxShadow: '0 0 10px 0 rgba(255,255,255,0.5)',
-      borderRadius: '50em',
-      width: `${padSize}px`,
-      height: `${padSize}px`,
-      transform: 'translate(0%,-100%)',
-      left: `${r.left + allMargin + lrMargin}px`,
-      top: `${joyStickCY + joyStickSR}px`,
-      display: !useJoyStick && isKeysShown ? 'block' : 'none'
-    })
+    // QWZX 整组（可整体拖动/缩放/透明；默认锚定右下角菱形）
+    const qcustom = activeCfg && activeCfg.buttons && activeCfg.buttons['qwzx']
+    const qscale = btnScale(qcustom)
     Object.assign(qwzxElement.style, {
       ...commonStyle,
       width: `${padSize}px`,
       height: `${padSize}px`,
-      transform: 'translate(-100%,-100%)',
       borderRadius: '50em',
-      boxShadow: '0 0 10px 0 rgba(255,255,255,0.5)',
-      left: `${r.left + r.width - allMargin}px`,
-      top: `${r.top + r.height - allMargin}px`,
-      display: isKeysShown ? 'block' : 'none'
+      boxShadow: '0 0 10px 0 rgba(255,255,255,0.5)'
     })
+    qwzxElement.__disp = showKeys ? 'block' : 'none'
+    applyFade(qwzxElement, qcustom)
+    if (qcustom && qcustom.x != null && qcustom.y != null) {
+      placeAtCenter(qwzxElement, qcustom, qscale, null)
+    } else {
+      qwzxElement.style.transform = 'translate(-100%,-100%)'
+      qwzxElement.style.left = `${r.left + r.width - allMargin}px`
+      qwzxElement.style.top = `${r.top + r.height - allMargin}px`
+      qwzxElement.style.transformOrigin = 'center'
+      if (qscale !== 1) qwzxElement.style.transform = 'translate(-100%,-100%) scale(' + qscale + ')'
+    }
     const btnW = padSize * 0.5
     const pitch = actionBtnH() + 5
-    const activeCfg = (editMode ? editConfig : padConfig)
     actionEls.forEach((el, i) => {
       const meta = el.__pad || {}
       const custom = activeCfg && activeCfg.buttons && activeCfg.buttons[meta.id]
       const scale = btnScale(custom)
-      if (custom && custom.visible === false) {
-        el.style.display = 'none'
-        return
-      }
       Object.assign(el.style, {
         ...btnStyle,
         width: `${btnW}px`,
         height: `${actionBtnH()}px`,
         lineHeight: `${actionBtnH()}px`,
         borderRadius: '50em',
-        right: 'auto',
-        left: `${r.left + r.width - allMargin - btnW}px`,
-        top: `${r.top + allMargin + i * pitch}px`,
-        transform: scale === 1 ? '' : `scale(${scale})`,
-        transformOrigin: 'center',
-        display: isKeysShown ? 'block' : 'none'
+        right: 'auto'
       })
-      if (custom && custom.x != null && custom.y != null) {
-        const r0 = el.getBoundingClientRect()
-        el.style.left = `${custom.x - r0.width / 2}px`
-        el.style.top = `${custom.y - r0.height / 2}px`
-      }
-    })
-    qwzxEls.forEach(el => {
-      const meta = el.__pad || {}
-      const activeCfgQ = (editMode ? editConfig : padConfig)
-      const custom = activeCfgQ && activeCfgQ.buttons && activeCfgQ.buttons[meta.id]
-      const scale = btnScale(custom)
-      if (custom && custom.visible === false) {
-        el.style.display = 'none'
-        return
-      }
-      el.style.display = isKeysShown ? 'block' : 'none'
-      if (custom && custom.x != null && custom.y != null) {
-        const r0 = el.getBoundingClientRect()
-        const pr = qwzxElement.getBoundingClientRect()
-        el.style.transform = scale === 1 ? '' : `scale(${scale})`
-        el.style.left = `${custom.x - r0.width / 2 - pr.left}px`
-        el.style.top = `${custom.y - r0.height / 2 - pr.top}px`
-        el.style.right = 'auto'
-        el.style.transformOrigin = 'center'
-      } else {
-        el.style.transform = (scale === 1 ? '' : `scale(${scale})`) + (el.__baseTransform || '')
-      }
+      el.style.left = (custom && custom.x != null ? 'auto' : `${r.left + r.width - allMargin - btnW}px`)
+      el.style.top = (custom && custom.y != null ? 'auto' : `${r.top + allMargin + i * pitch}px`)
+      el.__disp = showKeys ? 'block' : 'none'
+      el.style.transformOrigin = 'center'
+      applyFade(el, custom)
+      placeAtCenter(el, custom, scale, null)
     })
     // 发布动作键列区域，供修改器悬浮球避让（见 __rpgmaker_mod_ui.js）
     window.__touchPadMetrics = {
@@ -388,9 +445,10 @@ window.addEventListener('load', () => {
   }
   const setEventStart = (e, keyCodes) => {
     const press = (evt) => {
-      if (editMode) return
+      // 编辑模式也要拦截事件冒泡到游戏（游戏在 document 监听），仅跳过按键派发
       evt.stopPropagation()
       evt.preventDefault()
+      if (editMode) return
       setKeyDownColor(e)
       keyCodes.forEach(keyCode => {
         startKeyEvent(e, keyCode, 'keydown')
@@ -410,9 +468,9 @@ window.addEventListener('load', () => {
   }
   const setEventEnd = (e, keyCodes) => {
     const release = (evt) => {
-      if (editMode) return
       evt.stopPropagation()
       evt.preventDefault()
+      if (editMode) return
       setKeyUpColor(e)
       keyCodes.forEach(keyCode => {
         startKeyEvent(e, keyCode, 'keyup')
@@ -472,17 +530,20 @@ window.addEventListener('load', () => {
     el.addEventListener('touchstart', (evt) => {
       evt.stopPropagation()
       evt.preventDefault()
+      if (editMode) return
       setKeyDownColor(el)
     })
     el.addEventListener('mousedown', (evt) => {
       evt.stopPropagation()
       evt.preventDefault()
+      if (editMode) return
       setKeyDownColor(el)
     })
     setEventMove(el)
     const release = (evt) => {
       evt.stopPropagation()
       evt.preventDefault()
+      if (editMode) return
       setKeyUpColor(el)
       onRelease()
     }
@@ -530,18 +591,21 @@ window.addEventListener('load', () => {
   joyStickStage.addEventListener('touchstart', (evt) => {
     evt.stopPropagation()
     evt.preventDefault()
+    if (editMode) return
     const touch = evt.targetTouches[0]
     joyStart(touch.clientX, touch.clientY)
   })
   joyStickStage.addEventListener('touchmove', (evt) => {
     evt.stopPropagation()
     evt.preventDefault()
+    if (editMode) return
     const touch = evt.targetTouches[0]
     joyMove(touch.clientX, touch.clientY)
   })
   joyStickStage.addEventListener('touchend', (evt) => {
     evt.stopPropagation()
     evt.preventDefault()
+    if (editMode) return
     joyEnd()
   })
   // 虚拟鼠标拖拽摇杆：光标按下后跟随 mousemove
@@ -549,15 +613,18 @@ window.addEventListener('load', () => {
   joyStickStage.addEventListener('mousedown', (evt) => {
     evt.stopPropagation()
     evt.preventDefault()
+    if (editMode) return
     joyMouseDown = true
     joyStart(evt.clientX, evt.clientY)
   })
   window.addEventListener('mousemove', (evt) => {
+    if (editMode) return
     if (!joyMouseDown) return
     evt.stopPropagation()
     joyMove(evt.clientX, evt.clientY)
   })
   window.addEventListener('mouseup', (evt) => {
+    if (editMode) return
     if (!joyMouseDown) return
     evt.stopPropagation()
     joyMouseDown = false
@@ -598,6 +665,8 @@ window.addEventListener('load', () => {
     })
     childElement.__pad = { id: it.id, text: it.text, defaultKeyCode: it.keyCode }
     childElement.__baseTransform = it.style.transform || ''
+    childElement.__baseLeft = it.style.left || ''
+    childElement.__baseTop = it.style.top || ''
     qwzxEls.push(childElement)
     setEventStart(childElement, [it.keyCode])
     setEventMove(childElement)
@@ -616,20 +685,58 @@ window.addEventListener('load', () => {
   var panel = null
   var panelGrab = null         // 顶层控制框拖拽状态
   var NUDGE = 4
-  var allEditableEls = []      // [{ el, id }]
+  var allEditableEls = []      // [{ el, id, group }]
+  // 非数组型可编辑元素：3 个开关 + 摇杆外框 + 方向键圆盘 + QWZX 整组（视口锚定）
+  var fixedEls = [
+    { el: keySwitchElement, id: 'btn.hide', group: 'switch' },
+    { el: joyStickSwitchElement, id: 'btn.stick', group: 'switch' },
+    { el: dir8SwitchElement, id: 'btn.dir8', group: 'switch' },
+    { el: joyStickStage, id: 'joystick', group: 'stage' },
+    { el: udlrElement, id: 'dpad', group: 'stage' },
+    { el: qwzxElement, id: 'qwzx', group: 'stage' }
+  ]
+  // 进入编辑时需要抬到遮罩层(100000000)之上的容器（其子元素的可点区域被其堆叠上下文包含）
+  var editContainers = [actionsElement, qwzxElement, joyStickStage, udlrElement]
+  var editContainersZ = []
+  // 编辑模式下拦截输入冒泡到 document（游戏在 document 监听，点按会穿透到游戏）。
+  // 按钮/开关/摇杆自身 handler 已改为始终 stopPropagation；这里兜底遮罩、面板与容器空白区。
+  var editBlockers = []
+  var EDIT_INPUT_EVENTS = ['touchstart', 'touchmove', 'touchend', 'mousedown', 'mousemove', 'mouseup', 'pointerdown', 'pointermove', 'pointerup', 'click', 'contextmenu']
+  function installEditBlock(el) {
+    EDIT_INPUT_EVENTS.forEach(function (name) {
+      var fn = function (ev) { ev.stopPropagation(); ev.preventDefault() }
+      el.addEventListener(name, fn)
+      editBlockers.push({ el: el, name: name, fn: fn })
+    })
+  }
+  function removeEditBlock() {
+    editBlockers.forEach(function (b) {
+      if (b.el && b.el.removeEventListener) b.el.removeEventListener(b.name, b.fn)
+    })
+    editBlockers = []
+  }
 
   function collectEditable() {
     allEditableEls = []
-    actionEls.forEach(el => { if (el.__pad) allEditableEls.push({ el: el, id: el.__pad.id }) })
-    qwzxEls.forEach(el => { if (el.__pad) allEditableEls.push({ el: el, id: el.__pad.id }) })
+    actionEls.forEach(el => { if (el.__pad) allEditableEls.push({ el: el, id: el.__pad.id, group: 'action' }) })
+    fixedEls.forEach(f => { if (f.el.__pad) allEditableEls.push({ el: f.el, id: f.id, group: f.group }) })
   }
 
   function defaultButtonFor(id) {
+    var label = null
     var found = actionsBtns.concat(qwzxBtns).filter(function (b) { return b.id === id })[0]
-    return found && { x: null, y: null, scale: 1, visible: true, keyCode: found.keyCode, label: found.text }
+    if (found) { label = found.text }
+    else {
+      for (var i = 0; i < fixedEls.length; i++) {
+        if (fixedEls[i].id === id) { label = fixedEls[i].el.__pad.text; break }
+      }
+    }
+    if (!label) return null
+    return { x: null, y: null, scale: 1, visible: true, label: label }
   }
 
   function ensureButtonCfg(id) {
+    if (!id) return null
     if (!editConfig) editConfig = { buttons: {} }
     if (!editConfig.buttons[id]) editConfig.buttons[id] = defaultButtonFor(id)
     return editConfig.buttons[id]
@@ -643,61 +750,50 @@ window.addEventListener('load', () => {
   function styleButton(el, highlight) {
     var meta = el.__pad || {}
     var custom = editConfig && editConfig.buttons && editConfig.buttons[meta.id]
-    var scale = btnScale(custom)
-    el.classList.add('tm-pad-editable')
-    el.style.outline = highlight ? '3px solid #fff' : ''
+    var hidden = custom && custom.visible === false
+    if (highlight) {
+      el.style.outline = hidden ? '3px dashed #4a9eff' : '3px solid #4a9eff'
+      el.style.boxShadow = hidden ? '0 0 0 2px rgba(74,158,255,0.5), inset 0 0 0 40px rgba(74,158,255,0.35)' : '0 0 0 2px rgba(74,158,255,0.5)'
+    } else {
+      el.style.outline = ''
+      el.style.boxShadow = ''
+    }
     el.style.zIndex = (highlight ? '100000002' : '100000001')
   }
 
+  // 统一由 layout() 负责所有可编辑元素的定位/缩放/透明（编辑与普通模式一致）
   function refreshEditConfig() {
-    collectEditable()
-    allEditableEls.forEach(function (entry) {
-      var meta = entry.el.__pad || {}
-      var custom = editConfig && editConfig.buttons && editConfig.buttons[meta.id]
-      var scale = btnScale(custom)
-      if (custom && custom.visible === false) {
-        entry.el.style.display = 'none'
-        return
-      }
-      entry.el.style.display = 'block'
-      if (custom && custom.x != null && custom.y != null) {
-        var r0 = entry.el.getBoundingClientRect()
-        entry.el.style.transform = scale === 1 ? '' : 'scale(' + scale + ')'
-        entry.el.style.transformOrigin = 'center'
-        if (entry.el.__group === 'qwzx') {
-          var pr = qwzxElement.getBoundingClientRect()
-          entry.el.style.left = (custom.x - r0.width / 2 - pr.left) + 'px'
-          entry.el.style.top = (custom.y - r0.height / 2 - pr.top) + 'px'
-        } else {
-          entry.el.style.left = (custom.x - r0.width / 2) + 'px'
-          entry.el.style.top = (custom.y - r0.height / 2) + 'px'
-        }
-        entry.el.style.right = 'auto'
-      } else {
-        // 复用 layout 的默认定位：先恢复列布局，再应用 scale
-        entry.el.style.left = ''
-        entry.el.style.top = ''
-        entry.el.style.right = ''
-        if (entry.el.__group === 'qwzx') {
-          entry.el.style.transform = (scale === 1 ? '' : 'scale(' + scale + ')') + (entry.el.__baseTransform || '')
-        } else {
-          entry.el.style.transform = scale === 1 ? '' : 'scale(' + scale + ')'
-        }
-      }
-      if (entry.el.__group !== 'qwzx') entry.el.style.display = 'block'
-    })
+    layout()
+    if (selectedId) setSelected(selectedId)
   }
 
   function setSelected(id) {
     selectedId = id
     allEditableEls.forEach(function (entry) { styleButton(entry.el, entry.id === id) })
-    var custom = editConfig.buttons && editConfig.buttons[id]
-    var slider = panel && panel.querySelector('.tm-pad-scale')
-    if (slider) slider.value = String(Math.round(btnScale(custom) * 100))
+    var custom = id && editConfig.buttons && editConfig.buttons[id]
+    var nameLabel = panel && panel.querySelector('.tm-pad-selname')
+    if (nameLabel) {
+      var el = getElById(id)
+      nameLabel.textContent = el && el.__pad ? el.__pad.text + ' (' + id + ')' : '—'
+    }
+    updatePanelControls(custom)
+  }
+
+  function updatePanelControls(custom) {
+    var scalePct = Math.round(btnScale(custom) * 100)
     var scaleLabel = panel && panel.querySelector('.tm-pad-scaleval')
-    if (scaleLabel) scaleLabel.textContent = Math.round(btnScale(custom) * 100) + '%'
+    if (scaleLabel) scaleLabel.textContent = scalePct + '%'
+    var slider = panel && panel.querySelector('.tm-pad-scale')
+    if (slider) slider.value = String(scalePct)
     var visLabel = panel && panel.querySelector('.tm-pad-vislabel')
-    if (visLabel) visLabel.textContent = custom && custom.visible === false ? '（已隐藏）' : ''
+    if (visLabel) visLabel.textContent = custom && custom.visible === false ? '（透明·编辑中蓝显）' : ''
+    var transBtn = panel && panel.querySelector('[data-act="transparent"]')
+    if (transBtn) {
+      var sel = selectedId != null
+      transBtn.style.opacity = sel ? '1' : '0.4'
+      transBtn.style.pointerEvents = sel ? 'auto' : 'none'
+      transBtn.textContent = custom && custom.visible === false ? '恢复显示' : '透明'
+    }
   }
 
   function saveAndExit(force) {
@@ -717,13 +813,89 @@ window.addEventListener('load', () => {
       exitEdit()
       layout()
     }
+    // 有 <50% 缩放的按钮时，用面板内联确认（WebView 的 window.confirm 不可靠）
     if (!force && small.length > 0) {
-      if (window.confirm('有 ' + small.length + ' 个按钮缩放小于 50%，确认保存？')) doSave()
+      showSaveConfirm(small.length, doSave)
     } else {
       doSave()
     }
   }
 
+  // 面板内联确认行
+  function showSaveConfirm(count, onConfirm) {
+    if (!panel) return
+    var row = panel.querySelector('[data-act="confirmrow"]')
+    if (!row) return
+    var msg = panel.querySelector('[data-act="confirmmsg"]')
+    if (msg) msg.textContent = count + ' 个按钮缩放小于 50%，确认保存？'
+    row.style.display = 'flex'
+    var back = panel.querySelector('[data-act="confirmback"]')
+    if (back) back.onpointerdown = function (ev) { ev.stopPropagation(); ev.preventDefault(); row.style.display = 'none' }
+    var yes = panel.querySelector('[data-act="confirmyes"]')
+    if (yes) yes.onpointerdown = function (ev) { ev.stopPropagation(); ev.preventDefault(); onConfirm() }
+  }
+
+  // 长按连发：按住持续触发回调，松开停止（用于 +/- 缩放与微调）
+  function holdRepeat(el, fn, interval) {
+    var timer = null
+    var doFn = function (ev) {
+      ev.stopPropagation()
+      ev.preventDefault()
+      fn()
+      timer = setTimeout(function tick() {
+        fn()
+        timer = setTimeout(tick, interval || 100)
+      }, 350)
+    }
+    var stop = function (ev) {
+      if (ev) { ev.stopPropagation(); ev.preventDefault() }
+      if (timer) { clearTimeout(timer); timer = null }
+    }
+    el.addEventListener('pointerdown', doFn)
+    el.addEventListener('pointerup', stop)
+    el.addEventListener('pointercancel', stop)
+    el.addEventListener('pointerleave', stop)
+  }
+  // 面板动作键：pointerdown 触发（WebView 触摸路径 click 不可靠），并吞掉合成 click 防双触发
+  function bindTap(el, fn) {
+    el.addEventListener('pointerdown', function (ev) {
+      ev.stopPropagation()
+      ev.preventDefault()
+      fn()
+    })
+    el.addEventListener('click', function (ev) {
+      ev.stopPropagation()
+      ev.preventDefault()
+    })
+  }
+  // 从滑杆值(1..200)设置选中元素缩放
+  function scaleFromValue(pct) {
+    if (!selectedId) return
+    var c = ensureButtonCfg(selectedId)
+    c.scale = Math.max(1, Math.min(200, Math.round(pct))) / 100
+    refreshEditConfig()
+    setSelected(selectedId)
+  }
+  function nudgeSelected(dx, dy) {
+    if (!selectedId) return
+    var c = ensureButtonCfg(selectedId)
+    var el = getElById(selectedId)
+    if (!el) return
+    var pr = el.getBoundingClientRect()
+    c.x = (pr.left + pr.width / 2 + dx) / vw()
+    c.y = (pr.top + pr.height / 2 + dy) / vh()
+    refreshEditConfig()
+    setSelected(selectedId)
+  }
+  function scaleSelected(delta) {
+    if (!selectedId) return
+    var c = ensureButtonCfg(selectedId)
+    var cur = Math.round(btnScale(c) * 100)
+    var next = Math.max(1, Math.min(200, cur + delta))
+    c.scale = next / 100
+    refreshEditConfig()
+    setSelected(selectedId)
+  }
   function buildPanel() {
     var style = document.getElementById('tm-pad-edit-css')
     if (!style) {
@@ -731,34 +903,53 @@ window.addEventListener('load', () => {
       style.id = 'tm-pad-edit-css'
       style.textContent =
         '.tm-pad-editable{cursor:move}' +
-        '.tm-pad-btn{background:#3a3a4a;color:#fff;border:1px solid #666;border-radius:6px;padding:5px 10px;cursor:pointer;font:13px sans-serif}' +
+        '.tm-pad-faded{opacity:0.45;filter:grayscale(1);background:rgba(100,150,255,0.5);outline:1px dashed rgba(140,180,255,0.8)}' +
+        '.tm-pad-btn{background:#3a3a4a;color:#fff;border:1px solid #666;border-radius:8px;padding:8px 12px;cursor:pointer;font:14px sans-serif;touch-action:none}' +
         '.tm-pad-btn.primary{background:#2b6cb0}' +
-        '.tm-pad-nudge{background:#3a3a4a;color:#fff;border:1px solid #666;border-radius:5px;width:26px;height:26px;cursor:pointer;font:14px sans-serif}'
+        '.tm-pad-btn:disabled{opacity:0.4}' +
+        '.tm-pad-scalebtn{background:#3a3a4a;color:#fff;border:1px solid #666;border-radius:6px;width:34px;height:34px;cursor:pointer;font:18px sans-serif;touch-action:none}' +
+        '.tm-pad-nudge{background:#3a3a4a;color:#fff;border:1px solid #666;width:34px;height:34px;cursor:pointer;font:16px sans-serif;touch-action:none;position:absolute}'
       document.body.appendChild(style)
     }
     panel = document.createElement('div')
     panel.className = 'tm-pad-editpanel'
     panel.style.cssText = [
       'position:fixed', 'left:50%', 'top:10px', 'transform:translateX(-50%)',
-      'z-index:100000003', 'background:rgba(20,20,30,0.92)', 'color:#fff',
-      'border:1px solid #555', 'border-radius:12px', 'padding:10px 14px',
-      'max-width:calc(100vw - 20px)', 'box-shadow:0 4px 20px rgba(0,0,0,0.5)',
+      'z-index:100000003', 'background:rgba(20,20,30,0.94)', 'color:#fff',
+      'border:1px solid #555', 'border-radius:14px', 'padding:14px 18px',
+      'max-width:min(340px,92vw)', 'max-height:82vh', 'overflow-y:auto',
+      'box-shadow:0 4px 20px rgba(0,0,0,0.5)',
       'user-select:none', 'font:14px/1.5 sans-serif', 'touch-action:none'
     ].join(';')
     panel.innerHTML =
-      '<div class="tm-pad-title" style="font-weight:bold;margin-bottom:6px;cursor:move">键盘映射（拖动此框移动）</div>' +
-      '<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">' +
-      '<label>缩放 <input type="range" min="1" max="200" value="100" class="tm-pad-scale" style="width:90px"></label>' +
-      '<span class="tm-pad-scaleval">100%</span>' +
+      // 标题 + 缩放（滑杆 + +/- 按钮）+ 透明
+      '<div class="tm-pad-title" style="font-weight:bold;margin-bottom:8px;cursor:move">键盘映射 · 拖动控制或按钮调整（拖动框可移动）</div>' +
+      '<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:8px">' +
+      '<span>缩放</span>' +
+      '<button class="tm-pad-scalebtn" data-scale="-1">－</button>' +
+      '<input type="range" min="1" max="200" value="100" class="tm-pad-scale" style="flex:1;min-width:90px;touch-action:none">' +
+      '<button class="tm-pad-scalebtn" data-scale="+1">＋</button>' +
+      '<span class="tm-pad-scaleval" style="min-width:42px;text-align:center">100%</span>' +
+      '</div>' +
+      '<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:8px">' +
       '<button class="tm-pad-btn" data-act="transparent">透明</button>' +
       '<span class="tm-pad-vislabel" style="color:#ff9"></span>' +
       '</div>' +
-      '<div style="display:flex;align-items:center;gap:6px;margin-top:8px;flex-wrap:wrap">' +
-      '<span>微调</span>' +
-      '<button class="tm-pad-nudge" data-d="up">↑</button>' +
-      '<button class="tm-pad-nudge" data-d="left">←</button>' +
-      '<button class="tm-pad-nudge" data-d="right">→</button>' +
-      '<button class="tm-pad-nudge" data-d="down">↓</button>' +
+      // 微调（角落十字，位于面板右下）
+      '<div style="display:flex;align-items:center;justify-content:space-between;margin-top:8px">' +
+      '<span style="opacity:0.8">选择元素：<span class="tm-pad-selname" style="color:#7fd0ff">—</span></span>' +
+      '<div class="tm-pad-cross" style="position:relative;width:102px;height:102px">' +
+      '<button class="tm-pad-nudge" data-d="up" style="left:34px;top:0">↑</button>' +
+      '<button class="tm-pad-nudge" data-d="left" style="left:0;top:34px">←</button>' +
+      '<button class="tm-pad-nudge" data-d="right" style="left:68px;top:34px">→</button>' +
+      '<button class="tm-pad-nudge" data-d="down" style="left:34px;top:68px">↓</button>' +
+      '</div>' +
+      '</div>' +
+      // 内联确认行（默认隐藏）
+      '<div data-act="confirmrow" style="display:none;align-items:center;gap:8px;margin-top:10px;flex-wrap:wrap;background:rgba(74,158,255,0.15);border:1px solid #4a9eff;border-radius:8px;padding:8px">' +
+      '<span data-act="confirmmsg" style="flex:1;min-width:140px"></span>' +
+      '<button class="tm-pad-btn primary" data-act="confirmyes">确认保存</button>' +
+      '<button class="tm-pad-btn" data-act="confirmback">返回</button>' +
       '</div>' +
       '<div style="display:flex;align-items:center;gap:8px;margin-top:10px;flex-wrap:wrap">' +
       '<button class="tm-pad-btn primary" data-act="save">保存并退出</button>' +
@@ -780,42 +971,55 @@ window.addEventListener('load', () => {
     })
     panel.addEventListener('pointerup', function () { panelGrab = null })
     panel.addEventListener('pointercancel', function () { panelGrab = null })
-
-    var slider = panel.querySelector('.tm-pad-scale')
-    slider.addEventListener('input', function () {
-      if (!selectedId) return
-      var c = ensureButtonCfg(selectedId)
-      if (c.x == null && c.y == null) { var r = getElById(selectedId).getBoundingClientRect(); c.x = r.left + r.width / 2; c.y = r.top + r.height / 2 }
-      c.scale = Number(slider.value) / 100
-      refreshEditConfig()
-      setSelected(selectedId)
-    })
-    panel.querySelectorAll('.tm-pad-nudge').forEach(function (b) {
-      b.addEventListener('click', function () {
-        if (!selectedId) return
-        var c = ensureButtonCfg(selectedId)
-        var el = getElById(selectedId)
-        var pr = el.getBoundingClientRect()
-        c.x = pr.left + pr.width / 2
-        c.y = pr.top + pr.height / 2
-        var d = b.getAttribute('data-d')
-        if (d === 'up') c.y -= NUDGE
-        else if (d === 'down') c.y += NUDGE
-        else if (d === 'left') c.x -= NUDGE
-        else if (d === 'right') c.x += NUDGE
-        refreshEditConfig()
-        setSelected(selectedId)
+    // 缩放 +/-
+    panel.querySelectorAll('.tm-pad-scalebtn').forEach(function (b) {
+      holdRepeat(b, function () {
+        var sign = b.getAttribute('data-scale') === '+1' ? 1 : -1
+        scaleSelected(sign)
       })
     })
-    panel.querySelector('[data-act="transparent"]').addEventListener('click', function () {
+    // 缩放滑杆：pointer 手动拖拽（面板 touch-action:none 下原生滑杆触摸拖动失效）
+    var slider = panel.querySelector('.tm-pad-scale')
+    var sliderDrag = null
+    var sliderSet = function (ev) {
+      var r = slider.getBoundingClientRect()
+      var pct = Math.max(1, Math.min(200, Math.round((ev.clientX - r.left) / r.width * 199) + 1))
+      slider.value = String(pct)
+      scaleFromValue(pct)
+    }
+    slider.addEventListener('pointerdown', function (ev) {
+      ev.stopPropagation()
+      ev.preventDefault()
+      sliderDrag = true
+      try { slider.setPointerCapture(ev.pointerId) } catch (e) {}
+      sliderSet(ev)
+    })
+    slider.addEventListener('pointermove', function (ev) {
+      if (!sliderDrag) return
+      sliderSet(ev)
+    })
+    slider.addEventListener('pointerup', function () { sliderDrag = false })
+    slider.addEventListener('pointercancel', function () { sliderDrag = false })
+    slider.addEventListener('input', function () { if (!sliderDrag) scaleFromValue(Number(slider.value)) })
+    // 十字微调（pointer 路径，触摸可靠）
+    panel.querySelectorAll('.tm-pad-nudge').forEach(function (b) {
+      holdRepeat(b, function () {
+        var d = b.getAttribute('data-d')
+        var dxy = { up: [0, -NUDGE], down: [0, NUDGE], left: [-NUDGE, 0], right: [NUDGE, 0] }[d]
+        nudgeSelected(dxy[0], dxy[1])
+      })
+    })
+    // 透明/恢复（pointer 路径）
+    bindTap(panel.querySelector('[data-act="transparent"]'), function () {
       if (!selectedId) return
       var c = ensureButtonCfg(selectedId)
-      c.visible = false
+      if (c.visible === false) c.visible = true
+      else c.visible = false
       refreshEditConfig()
       setSelected(selectedId)
     })
-    panel.querySelector('[data-act="save"]').addEventListener('click', function () { saveAndExit(false) })
-    panel.querySelector('[data-act="reset"]').addEventListener('click', function () {
+    bindTap(panel.querySelector('[data-act="save"]'), function () { saveAndExit(false) })
+    bindTap(panel.querySelector('[data-act="reset"]'), function () {
       collectEditable()
       allEditableEls.forEach(function (entry) {
         var meta = entry.el.__pad || {}
@@ -823,9 +1027,8 @@ window.addEventListener('load', () => {
       })
       refreshEditConfig()
       if (selectedId) setSelected(selectedId)
-      layout()
     })
-    panel.querySelector('[data-act="cancel"]').addEventListener('click', function () {
+    bindTap(panel.querySelector('[data-act="cancel"]'), function () {
       editConfig = padConfig ? JSON.parse(JSON.stringify(padConfig)) : { buttons: {} }
       exitEdit()
       layout()
@@ -846,89 +1049,104 @@ window.addEventListener('load', () => {
       'background:rgba(0,0,0,0.65);z-index:100000000;touch-action:none'
     document.body.appendChild(overlay)
     buildPanel()
+    // 拦截编辑模式下冒泡到游戏的输入（遮罩/面板/容器空白区）
+    removeEditBlock()
+    installEditBlock(overlay)
+    installEditBlock(panel)
+    editContainers.forEach(function (el) { installEditBlock(el) })
     // 收集全部按钮并打上可编辑类
     collectEditable()
+    // 抬升容器 zIndex，使 qwzx/摇杆/方向键等堆叠上下文内容可点（高于遮罩层）
+    editContainersZ = editContainers.map(function (el) { var z = el.style.zIndex; el.style.zIndex = '100000005'; return z })
     allEditableEls.forEach(function (entry) {
       var el = entry.el
-      el.__group = qwzxEls.indexOf(el) >= 0 ? 'qwzx' : 'action'
+      el.__group = entry.group
       el.classList.add('tm-pad-editable')
       el.style.pointerEvents = 'auto'
     })
-    // 从已保存配置恢复工作副本位置（若首次编辑按默认布局落位）
-    collectEditable()
     allEditableEls.forEach(function (entry) {
       var meta = entry.el.__pad || {}
       var c = editConfig.buttons[meta.id]
       if (!c || c.x == null || c.y == null) {
         var r = entry.el.getBoundingClientRect()
         editConfig.buttons[meta.id] = c || defaultButtonFor(meta.id)
-        editConfig.buttons[meta.id].x = r.left + r.width / 2
-        editConfig.buttons[meta.id].y = r.top + r.height / 2
+        editConfig.buttons[meta.id].x = (r.left + r.width / 2) / vw()
+        editConfig.buttons[meta.id].y = (r.top + r.height / 2) / vh()
       }
     })
     refreshEditConfig()
-    // 选中第一个可见按钮方便直接调整
+    // 选中第一个可见按钮方便直接调整；无可见元素时确保控件处于禁用状态
     var first = allEditableEls.filter(function (e) { var c = editConfig.buttons[e.id]; return !c || c.visible !== false })[0]
-    if (first) setSelected(first.id)
+    setSelected(first ? first.id : null)
     attachEditDrag()
   }
 
-  function attachEditDrag() {
-    var target = null
+  // 幂等的拖拽绑定：重复进入也只会绑定一次；退出时按同一闭包精确解绑（排除监听泄漏）
+  function bindDrag(el) {
+    if (el.__dragBound) return
     var drag = null
-    function onDown(ev, el) {
+    function onDown(ev) {
+      if (!editMode) return
       ev.stopPropagation()
       ev.preventDefault()
       var meta = el.__pad || {}
       setSelected(meta.id)
       var c = ensureButtonCfg(meta.id)
-      c.visible = true
+      if (!c) return
       var r = el.getBoundingClientRect()
-      c.x = r.left + r.width / 2
-      c.y = r.top + r.height / 2
+      c.x = (r.left + r.width / 2) / vw()
+      c.y = (r.top + r.height / 2) / vh()
       drag = { id: meta.id, ox: ev.clientX, oy: ev.clientY, bx: c.x, by: c.y, moved: false }
     }
     function onMove(ev) {
-      if (!drag) return
+      if (!editMode || !drag) return
       var dx = ev.clientX - drag.ox
       var dy = ev.clientY - drag.oy
       if (!drag.moved && Math.abs(dx) + Math.abs(dy) < 8) return
       drag.moved = true
       var c = ensureButtonCfg(drag.id)
-      c.x = drag.bx + dx
-      c.y = drag.by + dy
+      if (!c) return
+      c.x = drag.bx + dx / vw()
+      c.y = drag.by + dy / vh()
       refreshEditConfig()
+      setSelected(drag.id)
     }
-    function onUp() { drag = null }
-
-    allEditableEls.forEach(function (entry) {
-      entry.el.removeEventListener('pointerdown', entry._pd)
-      entry.el.removeEventListener('pointermove', entry._pm)
-      entry.el.removeEventListener('pointerup', entry._pu)
-      entry._pd = function (ev) { onDown(ev, entry.el) }
-      entry._pm = onMove
-      entry._pu = onUp
-      entry.el.addEventListener('pointerdown', entry._pd)
-      entry.el.addEventListener('pointermove', entry._pm)
-      entry.el.addEventListener('pointerup', entry._pu)
-    })
-    if (overlay) {
-      overlay.addEventListener('pointerup', onUp)
-      overlay.addEventListener('pointercancel', onUp)
+    function onUp(ev) {
+      if (ev) { ev.preventDefault(); ev.stopPropagation() }
+      drag = null
     }
+    el.__dragDown = onDown
+    el.__dragMove = onMove
+    el.__dragUp = onUp
+    el.addEventListener('pointerdown', onDown)
+    el.addEventListener('pointermove', onMove)
+    el.addEventListener('pointerup', onUp)
+    el.__dragBound = true
+  }
+  function unbindDrag(el) {
+    if (!el.__dragBound) return
+    el.removeEventListener('pointerdown', el.__dragDown)
+    el.removeEventListener('pointermove', el.__dragMove)
+    el.removeEventListener('pointerup', el.__dragUp)
+    el.__dragDown = null
+    el.__dragMove = null
+    el.__dragUp = null
+    el.__dragBound = false
+    el.style.outline = ''
+  }
+  function attachEditDrag() {
+    collectEditable()
+    allEditableEls.forEach(function (entry) { bindDrag(entry.el) })
   }
 
   function exitEdit() {
     editMode = false
+    removeEditBlock()
+    collectEditable()
     allEditableEls.forEach(function (entry) {
-      if (entry.el._pd) entry.el.removeEventListener('pointerdown', entry._pd)
-      if (entry.el._pm) entry.el.removeEventListener('pointermove', entry._pm)
-      if (entry.el._pu) entry.el.removeEventListener('pointerup', entry._pu)
-      delete entry.el._pd
-      delete entry.el._pm
-      delete entry.el._pu
+      unbindDrag(entry.el)
       entry.el.classList.remove('tm-pad-editable')
-      entry.el.style.outline = ''
+      entry.el.style.pointerEvents = ''
     })
     if (overlay && overlay.parentNode) overlay.parentNode.removeChild(overlay)
     overlay = null
@@ -936,6 +1154,10 @@ window.addEventListener('load', () => {
     panel = null
     panelGrab = null
     selectedId = null
+    editContainers.forEach(function (el, i) {
+      el.style.zIndex = editContainersZ[i] || ''
+    })
+    layout()
   }
 
   // 恢复默认布局：清空配置并持久化（可在编辑面板或从悬浮球触发）
@@ -966,7 +1188,13 @@ window.addEventListener('load', () => {
   }
 
   layout()
-  window.addEventListener('resize', layout)
+  window.addEventListener('resize', function () {
+    if (editMode) refreshEditConfig()
+    else layout()
+  })
   // 旋转后画布矩形可能滞后于视口变化，延迟一帧再排
-  window.addEventListener('orientationchange', () => setTimeout(layout, 150))
+  window.addEventListener('orientationchange', () => setTimeout(function () {
+    if (editMode) refreshEditConfig()
+    else layout()
+  }, 150))
 })

--- a/engine/src/main/assets/__touch_pad.js
+++ b/engine/src/main/assets/__touch_pad.js
@@ -55,6 +55,12 @@ window.addEventListener('load', () => {
   // 坐标采用「归一化」（相对视口 0..1），横竖屏切换后按比例重映射，位置不漂移。
   const vw = () => window.innerWidth || 1
   const vh = () => window.innerHeight || 1
+  // 归一化坐标统一钳制：允许小幅出界便于摆放半出屏按钮，但杜绝坐标漂离视口后无法拖回，
+  // 也避免下次加载时被 x>1 的像素迁移启发式误判反复腐蚀
+  const clampCoord = (v) => {
+    const n = Number(v)
+    return Math.max(-0.1, Math.min(1.1, isFinite(n) ? n : 0))
+  }
   let padConfig = null
   try {
     const raw = window.__touchPadConfig
@@ -68,6 +74,10 @@ window.addEventListener('load', () => {
           if (b && b.x != null) b.x = b.x / vw()
           if (b && b.y != null) b.y = b.y / vh()
         })
+        // 迁移结果立即写回，避免未保存期间换朝向后以不同视口反复迁移、位置漂移
+        if (window.TyranorTouchPadNative && window.TyranorTouchPadNative.saveConfig) {
+          window.TyranorTouchPadNative.saveConfig(JSON.stringify(raw))
+        }
       }
       padConfig = raw
     }
@@ -840,12 +850,16 @@ window.addEventListener('load', () => {
     if (yes) yes.onpointerdown = function (ev) { ev.stopPropagation(); ev.preventDefault(); onConfirm() }
   }
 
+  // 长按连发活动终止器登记表：exitEdit 统一 clearTimeout，
+  // 防止面板被销毁/触摸流被打断后 setTimeout 链孤儿化永续空转
+  var holdStops = []
   // 长按连发：按住持续触发回调，松开停止（用于 +/- 缩放与微调）
   function holdRepeat(el, fn, interval) {
     var timer = null
     var doFn = function (ev) {
       ev.stopPropagation()
       ev.preventDefault()
+      if (timer != null) return // 重入保护：第二根手指同按不再叠加新的连发链
       fn()
       timer = setTimeout(function tick() {
         fn()
@@ -860,6 +874,7 @@ window.addEventListener('load', () => {
     el.addEventListener('pointerup', stop)
     el.addEventListener('pointercancel', stop)
     el.addEventListener('pointerleave', stop)
+    holdStops.push(stop)
   }
   // 面板动作键：pointerdown 触发（WebView 触摸路径 click 不可靠），并吞掉合成 click 防双触发
   function bindTap(el, fn) {
@@ -887,8 +902,8 @@ window.addEventListener('load', () => {
     var el = getElById(selectedId)
     if (!el) return
     var pr = el.getBoundingClientRect()
-    c.x = (pr.left + pr.width / 2 + dx) / vw()
-    c.y = (pr.top + pr.height / 2 + dy) / vh()
+    c.x = clampCoord((pr.left + pr.width / 2 + dx) / vw())
+    c.y = clampCoord((pr.top + pr.height / 2 + dy) / vh())
     refreshEditConfig()
     setSelected(selectedId)
   }
@@ -902,6 +917,8 @@ window.addEventListener('load', () => {
     setSelected(selectedId)
   }
   function buildPanel() {
+    // 每次进入编辑都重建面板：清掉上一轮会话的登记，避免 holdStops 无限增长
+    holdStops = []
     var style = document.getElementById('tm-pad-edit-css')
     if (!style) {
       style = document.createElement('style')
@@ -1034,6 +1051,12 @@ window.addEventListener('load', () => {
     bindTap(panel.querySelector('[data-act="transparent"]'), function () {
       if (!selectedId) return
       var c = ensureButtonCfg(selectedId)
+      if (selectedId === 'btn.hide' && c.visible !== false) {
+        // 隐藏键自身不允许透明：一旦真隐藏，普通模式下游戏内无出路（修改器关闭时连 FAB 都没有）
+        var hl = panel && panel.querySelector('.tm-pad-vislabel')
+        if (hl) hl.textContent = '隐藏键不可透明'
+        return
+      }
       if (c.visible === false) c.visible = true
       else c.visible = false
       refreshEditConfig()
@@ -1070,6 +1093,16 @@ window.addEventListener('load', () => {
     if (previewMode) exitPreview()
     setFabHidden(true)
     editMode = true
+    // 置位后任何一步失败都必须回滚，否则虚拟键失灵且 FAB 已隐藏、游戏内无法自救
+    try {
+      startEditSession()
+    } catch (e) {
+      console.error('enterEdit failed', e)
+      try { exitEdit() } catch (_ignored) {}
+    }
+  }
+
+  function startEditSession() {
     editConfig = padConfig ? JSON.parse(JSON.stringify(padConfig)) : { buttons: {} }
     overlay = document.createElement('div')
     overlay.style.cssText = 'position:fixed;left:0;top:0;width:100%;height:100%;' +
@@ -1091,14 +1124,18 @@ window.addEventListener('load', () => {
       el.classList.add('tm-pad-editable')
       el.style.pointerEvents = 'auto'
     })
+    // 先按编辑态布局一次：强制隐藏控件（如默认摇杆模式下的方向键、被 Hide 的键盘）
+    // 渲染出实际矩形，避免随后采集 getBoundingClientRect 得到 (0,0) 并写入持久化配置
+    refreshEditConfig()
     allEditableEls.forEach(function (entry) {
       var meta = entry.el.__pad || {}
       var c = editConfig.buttons[meta.id]
       if (!c || c.x == null || c.y == null) {
         var r = entry.el.getBoundingClientRect()
+        if (!r.width && !r.height) return
         editConfig.buttons[meta.id] = c || defaultButtonFor(meta.id)
-        editConfig.buttons[meta.id].x = (r.left + r.width / 2) / vw()
-        editConfig.buttons[meta.id].y = (r.top + r.height / 2) / vh()
+        editConfig.buttons[meta.id].x = clampCoord((r.left + r.width / 2) / vw())
+        editConfig.buttons[meta.id].y = clampCoord((r.top + r.height / 2) / vh())
       }
     })
     refreshEditConfig()
@@ -1121,8 +1158,8 @@ window.addEventListener('load', () => {
       var c = ensureButtonCfg(meta.id)
       if (!c) return
       var r = el.getBoundingClientRect()
-      c.x = (r.left + r.width / 2) / vw()
-      c.y = (r.top + r.height / 2) / vh()
+      c.x = clampCoord((r.left + r.width / 2) / vw())
+      c.y = clampCoord((r.top + r.height / 2) / vh())
       drag = { id: meta.id, ox: ev.clientX, oy: ev.clientY, bx: c.x, by: c.y, moved: false }
     }
     function onMove(ev) {
@@ -1133,8 +1170,8 @@ window.addEventListener('load', () => {
       drag.moved = true
       var c = ensureButtonCfg(drag.id)
       if (!c) return
-      c.x = drag.bx + dx / vw()
-      c.y = drag.by + dy / vh()
+      c.x = clampCoord(drag.bx + dx / vw())
+      c.y = clampCoord(drag.by + dy / vh())
       refreshEditConfig()
       setSelected(drag.id)
     }
@@ -1170,6 +1207,9 @@ window.addEventListener('load', () => {
     editMode = false
     removeEditBlock()
     blurPresetInput()
+    // 终止所有长按连发链（可能在面板销毁后因触摸流被打断而残留）
+    holdStops.forEach(function (stop) { stop() })
+    holdStops = []
     setFabHidden(false)
     collectEditable()
     allEditableEls.forEach(function (entry) {
@@ -1189,21 +1229,23 @@ window.addEventListener('load', () => {
     layout()
   }
 
-  // 恢复默认布局：清空配置并持久化（可在编辑面板或从悬浮球触发）
+  // 恢复默认布局：清空配置。非编辑态即时持久化；编辑态仅重置工作副本，与整体草稿模型
+  // 保持一致——立即持久化会让随后的「取消」无法回退到用户原有布局
   function resetToDefaults() {
-    padConfig = { buttons: {} }
-    if (editMode) editConfig = { buttons: {} }
-    try {
-      if (window && window.TyranorTouchPadNative && window.TyranorTouchPadNative.saveConfig) {
-        window.TyranorTouchPadNative.saveConfig('{}')
-      }
-    } catch (e) { /* 忽略 */ }
     if (editMode) {
+      editConfig = { buttons: {} }
       collectEditable()
       refreshEditConfig()
       if (selectedId) setSelected(selectedId)
+    } else {
+      padConfig = { buttons: {} }
+      try {
+        if (window && window.TyranorTouchPadNative && window.TyranorTouchPadNative.saveConfig) {
+          window.TyranorTouchPadNative.saveConfig('{}')
+        }
+      } catch (e) { /* 忽略 */ }
+      layout()
     }
-    layout()
   }
 
   // ================= 预设（保存/载入/重命名/删除，最多 10 个，名称 ≤12 字） =================
@@ -1426,35 +1468,14 @@ window.addEventListener('load', () => {
       previewMode = true
       setFabHidden(true)
       previewRestore = padConfig
-      previewOverlay = document.createElement('div')
-      previewOverlay.style.cssText = 'position:fixed;left:0;top:0;width:100%;height:100%;' +
-        'background:rgba(0,0,0,0.25);z-index:100000000;touch-action:none'
-      document.body.appendChild(previewOverlay)
-      previewBanner = document.createElement('div')
-      previewBanner.className = 'tm-pad-preview-banner'
-      previewBanner.style.cssText = [
-        'position:fixed', 'left:50%', 'top:14px', 'transform:translateX(-50%)',
-        'z-index:100000010', 'background:rgba(20,20,30,0.95)', 'color:#fff',
-        'border:1px solid #4a9eff', 'border-radius:12px', 'padding:8px 14px',
-        'display:flex', 'align-items:center', 'gap:10px',
-        'font:14px/1.4 sans-serif', 'box-shadow:0 4px 20px rgba(0,0,0,0.5)',
-        'user-select:none', 'touch-action:none', 'max-width:92vw'
-      ].join(';')
-      var label = document.createElement('span')
-      label.className = 'tm-pad-preview-name'
-      label.style.cssText = 'white-space:nowrap;overflow:hidden;text-overflow:ellipsis'
-      label.textContent = '预览：' + name
-      previewBanner.appendChild(label)
-      var btn = document.createElement('button')
-      btn.className = 'tm-pad-btn primary'
-      btn.textContent = '退出预览'
-      btn.style.cssText = 'padding:6px 12px;font:13px sans-serif'
-      previewBanner.appendChild(btn)
-      document.body.appendChild(previewBanner)
-      bindTap(btn, function () { exitPreview() })
-      removeEditBlock()
-      installEditBlock(previewOverlay)
-      installEditBlock(previewBanner)
+      // 建场失败必须回滚：否则 previewMode 卡在 true 且 FAB 已隐藏，游戏内没有退出入口
+      try {
+        startPreviewSession(name)
+      } catch (e) {
+        console.error('previewPreset failed', e)
+        try { exitPreview() } catch (_ignored) {}
+        return { ok: false, msg: '预览开启失败' }
+      }
     } else {
       var nm = previewBanner && previewBanner.querySelector('.tm-pad-preview-name')
       if (nm) nm.textContent = '预览：' + name
@@ -1463,6 +1484,40 @@ window.addEventListener('load', () => {
     layout()
     return { ok: true, msg: '' }
   }
+
+  // 建立预览遮罩与只读横幅；异常由 previewPreset 兜底回滚（原 padConfig 已存入 previewRestore）
+  function startPreviewSession(name) {
+    previewOverlay = document.createElement('div')
+    previewOverlay.style.cssText = 'position:fixed;left:0;top:0;width:100%;height:100%;' +
+      'background:rgba(0,0,0,0.25);z-index:100000000;touch-action:none'
+    document.body.appendChild(previewOverlay)
+    previewBanner = document.createElement('div')
+    previewBanner.className = 'tm-pad-preview-banner'
+    previewBanner.style.cssText = [
+      'position:fixed', 'left:50%', 'top:14px', 'transform:translateX(-50%)',
+      'z-index:100000010', 'background:rgba(20,20,30,0.95)', 'color:#fff',
+      'border:1px solid #4a9eff', 'border-radius:12px', 'padding:8px 14px',
+      'display:flex', 'align-items:center', 'gap:10px',
+      'font:14px/1.4 sans-serif', 'box-shadow:0 4px 20px rgba(0,0,0,0.5)',
+      'user-select:none', 'touch-action:none', 'max-width:92vw'
+    ].join(';')
+    var label = document.createElement('span')
+    label.className = 'tm-pad-preview-name'
+    label.style.cssText = 'white-space:nowrap;overflow:hidden;text-overflow:ellipsis'
+    label.textContent = '预览：' + name
+    previewBanner.appendChild(label)
+    var btn = document.createElement('button')
+    btn.className = 'tm-pad-btn primary'
+    btn.textContent = '退出预览'
+    btn.style.cssText = 'padding:6px 12px;font:13px sans-serif'
+    previewBanner.appendChild(btn)
+    document.body.appendChild(previewBanner)
+    bindTap(btn, function () { exitPreview() })
+    removeEditBlock()
+    installEditBlock(previewOverlay)
+    installEditBlock(previewBanner)
+  }
+
   function exitPreview() {
     if (!previewMode) return
     previewMode = false

--- a/engine/src/main/java/com/core/engine/EnginePrefs.kt
+++ b/engine/src/main/java/com/core/engine/EnginePrefs.kt
@@ -10,6 +10,13 @@ object EnginePrefs {
     const val APP_PREFS = "yukihub_prefs"
     const val NATIVE_PLUGIN_OVERRIDE_PREFS = "rinne_native_plugin_overrides"
 
+    /**
+     * 单游戏引擎设置覆盖层 prefs 文件名。
+     * 由 app 侧 PerGameSettingsStore 与引擎 TyranoActivity / TouchPadSaveBridge 共同读写；
+     * 引擎不得反向依赖 app，故契约锚点定在 engine、app 直接引用本常量，避免两侧字面量漂移。
+     */
+    const val GAME_OVERRIDES_PREFS = "tyranor_game_overrides"
+
     /** Tyrano 外部网络开关偏好键（镜像 app 模块 EngineSaveKeys.KEY_TYRANO_EXTERNAL_NETWORK）。 */
     const val KEY_TYRANO_EXTERNAL_NETWORK = "tyrano_external_network"
 

--- a/engine/src/main/java/com/core/tyrano/TyranoActivity.kt
+++ b/engine/src/main/java/com/core/tyrano/TyranoActivity.kt
@@ -886,6 +886,32 @@ class TyranoActivity : Activity() {
                 // 保留现有配置
             }
         }
+
+        @JavascriptInterface
+        fun getPresets(): String = try {
+            preferences.getString(gameId, null)?.let { raw ->
+                JSONObject(raw).optString(PER_GAME_TOUCH_PAD_PRESETS_KEY)
+            }.orEmpty()
+        } catch (_: Throwable) {
+            ""
+        }
+
+        @JavascriptInterface
+        fun savePresets(raw: String?) {
+            if (gameId.isBlank()) return
+            try {
+                val existing = runCatching { preferences.getString(gameId, null)?.let { JSONObject(it) } }
+                    .getOrNull() ?: JSONObject()
+                if (raw.isNullOrBlank() || JSONObject(raw).length() == 0) {
+                    existing.remove(PER_GAME_TOUCH_PAD_PRESETS_KEY)
+                } else {
+                    existing.put(PER_GAME_TOUCH_PAD_PRESETS_KEY, JSONObject(raw))
+                }
+                preferences.edit().putString(gameId, existing.toString()).apply()
+            } catch (_: Throwable) {
+                // 保留现有预设
+            }
+        }
     }
 
     private enum class WebGameType(val intentValue: String) {
@@ -922,6 +948,7 @@ class TyranoActivity : Activity() {
         private const val RPG_MAKER_MOD_PREFS = "tyranor_rpgmaker_mod_state"
         private const val GAME_OVERRIDES_PREFS = "tyranor_game_overrides"
         private const val PER_GAME_TOUCH_PAD_KEY = "touch_pad_config"
+        private const val PER_GAME_TOUCH_PAD_PRESETS_KEY = "touch_pad_presets"
         private const val RPG_MAKER_MOD_CORE_ASSET = "__rpgmaker_mod_core.js"
         private const val RPG_MAKER_MOD_UI_ASSET = "__rpgmaker_mod_ui.js"
         private const val RPG_MAKER_MOD_CSS_ASSET = "__rpgmaker_mod.css"

--- a/engine/src/main/java/com/core/tyrano/TyranoActivity.kt
+++ b/engine/src/main/java/com/core/tyrano/TyranoActivity.kt
@@ -136,9 +136,24 @@ class TyranoActivity : Activity() {
             }
             // 触屏手柄（issue #35）：MV/MZ 共用 __touch_pad.js，拼接进 hook 注入，
             // 独立于修改器开关。手柄代码零引擎依赖，MV/MZ 的 Input 均读 keyCode。
+            // issue #30：游戏内可自定义按钮布局，逐游戏配置在此注入供 JS 读取。
+            val isRpgWebGame = webGameType == WebGameType.RPG_MV || webGameType == WebGameType.RPG_MZ
+            val touchPadConf = if (isRpgWebGame && rpgMakerModGameId.isNotBlank()) {
+                getSharedPreferences(GAME_OVERRIDES_PREFS, Context.MODE_PRIVATE)
+                    .getString(rpgMakerModGameId, null)?.let { raw ->
+                        runCatching { JSONObject(raw).optString(PER_GAME_TOUCH_PAD_KEY) }
+                            .getOrNull()?.takeIf { it.isNotBlank() }
+                    }
+            } else {
+                null
+            }
+            val touchPadConfigJs = touchPadConf?.takeIf { it.isNotBlank() }?.let {
+                "window.__touchPadConfig=$it;"
+            }.orEmpty()
             val touchPad =
-                if (webGameType == WebGameType.RPG_MV || webGameType == WebGameType.RPG_MZ) {
-                    try { loadAsset(TOUCH_PAD_ASSET) } catch (_: Exception) { ByteArray(0) }
+                if (isRpgWebGame) {
+                    val pad = try { String(loadAsset(TOUCH_PAD_ASSET), Charsets.UTF_8) } catch (_: Exception) { "" }
+                    (touchPadConfigJs + "\n" + pad).toByteArray(Charsets.UTF_8)
                 } else {
                     ByteArray(0)
                 }
@@ -205,6 +220,10 @@ class TyranoActivity : Activity() {
         when (webGameType) {
             WebGameType.RPG_MV, WebGameType.RPG_MZ -> {
                 browser.addJavascriptInterface(RpgMakerSaveBridge(saves), RPG_MAKER_SAVE_BRIDGE_NAME)
+                browser.addJavascriptInterface(
+                    TouchPadSaveBridge(rpgMakerModGameId),
+                    TOUCH_PAD_BRIDGE_NAME,
+                )
                 if (rpgMakerModEnabled) {
                     browser.addJavascriptInterface(
                         RpgMakerModBridge(rpgMakerModGameId),
@@ -836,6 +855,39 @@ class TyranoActivity : Activity() {
         }
     }
 
+    /** 触屏手柄游戏内布局保存桥（issue #30）：按游戏持久化自定义布局。 */
+    inner class TouchPadSaveBridge(private val gameId: String) {
+        private val preferences
+            get() = getSharedPreferences(GAME_OVERRIDES_PREFS, Context.MODE_PRIVATE)
+
+        @JavascriptInterface
+        fun getConfig(): String = try {
+            preferences.getString(gameId, null)?.let { raw ->
+                JSONObject(raw).optString(PER_GAME_TOUCH_PAD_KEY)
+            }.orEmpty()
+        } catch (_: Throwable) {
+            ""
+        }
+
+        @JavascriptInterface
+        fun saveConfig(raw: String?) {
+            if (gameId.isBlank() || raw.isNullOrBlank()) return
+            try {
+                val input = JSONObject(raw)
+                val existing = runCatching { preferences.getString(gameId, null)?.let { JSONObject(it) } }
+                    .getOrNull() ?: JSONObject()
+                if (input.length() == 0) {
+                    existing.remove(PER_GAME_TOUCH_PAD_KEY)
+                } else {
+                    existing.put(PER_GAME_TOUCH_PAD_KEY, input)
+                }
+                preferences.edit().putString(gameId, existing.toString()).apply()
+            } catch (_: Throwable) {
+                // 保留现有配置
+            }
+        }
+    }
+
     private enum class WebGameType(val intentValue: String) {
         TYRANO("Tyrano"),
         RPG_MV("RPG"),
@@ -861,12 +913,15 @@ class TyranoActivity : Activity() {
         private const val JS_BRIDGE_NAME = "appJsInterface"
         private const val RPG_MAKER_SAVE_BRIDGE_NAME = "saveDataManager"
         private const val RPG_MAKER_MOD_BRIDGE_NAME = "TyranorModNative"
+        private const val TOUCH_PAD_BRIDGE_NAME = "TyranorTouchPadNative"
         private const val RPG_MV_SAVE_EXTENSION = ".bin"
         private const val EXTRA_SCOPED_SAVE_DIR = "scopedSaveDir"
         private const val EXTRA_SCOPED_SAVE_ROOT = "scopedSaveRoot"
         private const val EXTRA_RPG_MAKER_MOD_ENABLED = "rpgMakerModEnabled"
         private const val EXTRA_RPG_MAKER_MOD_GAME_ID = "rpgMakerModGameId"
         private const val RPG_MAKER_MOD_PREFS = "tyranor_rpgmaker_mod_state"
+        private const val GAME_OVERRIDES_PREFS = "tyranor_game_overrides"
+        private const val PER_GAME_TOUCH_PAD_KEY = "touch_pad_config"
         private const val RPG_MAKER_MOD_CORE_ASSET = "__rpgmaker_mod_core.js"
         private const val RPG_MAKER_MOD_UI_ASSET = "__rpgmaker_mod_ui.js"
         private const val RPG_MAKER_MOD_CSS_ASSET = "__rpgmaker_mod.css"

--- a/engine/src/main/java/com/core/tyrano/TyranoActivity.kt
+++ b/engine/src/main/java/com/core/tyrano/TyranoActivity.kt
@@ -139,7 +139,7 @@ class TyranoActivity : Activity() {
             // issue #30：游戏内可自定义按钮布局，逐游戏配置在此注入供 JS 读取。
             val isRpgWebGame = webGameType == WebGameType.RPG_MV || webGameType == WebGameType.RPG_MZ
             val touchPadConf = if (isRpgWebGame && rpgMakerModGameId.isNotBlank()) {
-                getSharedPreferences(GAME_OVERRIDES_PREFS, Context.MODE_PRIVATE)
+                getSharedPreferences(EnginePrefs.GAME_OVERRIDES_PREFS, Context.MODE_PRIVATE)
                     .getString(rpgMakerModGameId, null)?.let { raw ->
                         runCatching { JSONObject(raw).optString(PER_GAME_TOUCH_PAD_KEY) }
                             .getOrNull()?.takeIf { it.isNotBlank() }
@@ -855,59 +855,65 @@ class TyranoActivity : Activity() {
         }
     }
 
-    /** 触屏手柄游戏内布局保存桥（issue #30）：按游戏持久化自定义布局。 */
+    /** 触屏手柄游戏内布局保存桥（issue #30）：按游戏持久化自定义布局与预设。 */
     inner class TouchPadSaveBridge(private val gameId: String) {
         private val preferences
-            get() = getSharedPreferences(GAME_OVERRIDES_PREFS, Context.MODE_PRIVATE)
+            get() = getSharedPreferences(EnginePrefs.GAME_OVERRIDES_PREFS, Context.MODE_PRIVATE)
 
-        @JavascriptInterface
-        fun getConfig(): String = try {
+        // touch_pad_config / touch_pad_presets 键目前仅 engine 侧读写（常量留在本文件）；
+        // 与 PerGameSettingsStore 的其它引擎字段共存于同一条 JSON 记录，必须整条读改写以保留他人字段。
+        // 已知限制：app 主线程的设置页写路径与本桥线程之间暂无跨层互斥，极端并发下存在丢更新窗口，
+        // 后续如需彻底收口应把该记录的全部读写收敛到单一同步入口。
+        private fun readField(key: String): String = try {
             preferences.getString(gameId, null)?.let { raw ->
-                JSONObject(raw).optString(PER_GAME_TOUCH_PAD_KEY)
+                JSONObject(raw).optString(key)
             }.orEmpty()
         } catch (_: Throwable) {
             ""
         }
+
+        private fun updateRecord(mutate: (JSONObject) -> Unit) {
+            val existing = runCatching { preferences.getString(gameId, null)?.let { JSONObject(it) } }
+                .getOrNull() ?: JSONObject()
+            mutate(existing)
+            preferences.edit().putString(gameId, existing.toString()).apply()
+        }
+
+        @JavascriptInterface
+        fun getConfig(): String = readField(PER_GAME_TOUCH_PAD_KEY)
 
         @JavascriptInterface
         fun saveConfig(raw: String?) {
             if (gameId.isBlank() || raw.isNullOrBlank()) return
             try {
                 val input = JSONObject(raw)
-                val existing = runCatching { preferences.getString(gameId, null)?.let { JSONObject(it) } }
-                    .getOrNull() ?: JSONObject()
-                if (input.length() == 0) {
-                    existing.remove(PER_GAME_TOUCH_PAD_KEY)
-                } else {
-                    existing.put(PER_GAME_TOUCH_PAD_KEY, input)
+                updateRecord { record ->
+                    if (input.length() == 0) {
+                        record.remove(PER_GAME_TOUCH_PAD_KEY)
+                    } else {
+                        // 统一字符串形态落盘，与 PerGameSettingsStore.setStr 的包裹方式一致
+                        record.put(PER_GAME_TOUCH_PAD_KEY, input.toString())
+                    }
                 }
-                preferences.edit().putString(gameId, existing.toString()).apply()
             } catch (_: Throwable) {
                 // 保留现有配置
             }
         }
 
         @JavascriptInterface
-        fun getPresets(): String = try {
-            preferences.getString(gameId, null)?.let { raw ->
-                JSONObject(raw).optString(PER_GAME_TOUCH_PAD_PRESETS_KEY)
-            }.orEmpty()
-        } catch (_: Throwable) {
-            ""
-        }
+        fun getPresets(): String = readField(PER_GAME_TOUCH_PAD_PRESETS_KEY)
 
         @JavascriptInterface
         fun savePresets(raw: String?) {
             if (gameId.isBlank()) return
             try {
-                val existing = runCatching { preferences.getString(gameId, null)?.let { JSONObject(it) } }
-                    .getOrNull() ?: JSONObject()
-                if (raw.isNullOrBlank() || JSONObject(raw).length() == 0) {
-                    existing.remove(PER_GAME_TOUCH_PAD_PRESETS_KEY)
-                } else {
-                    existing.put(PER_GAME_TOUCH_PAD_PRESETS_KEY, JSONObject(raw))
+                updateRecord { record ->
+                    if (raw.isNullOrBlank() || JSONObject(raw).length() == 0) {
+                        record.remove(PER_GAME_TOUCH_PAD_PRESETS_KEY)
+                    } else {
+                        record.put(PER_GAME_TOUCH_PAD_PRESETS_KEY, JSONObject(raw).toString())
+                    }
                 }
-                preferences.edit().putString(gameId, existing.toString()).apply()
             } catch (_: Throwable) {
                 // 保留现有预设
             }
@@ -946,7 +952,6 @@ class TyranoActivity : Activity() {
         private const val EXTRA_RPG_MAKER_MOD_ENABLED = "rpgMakerModEnabled"
         private const val EXTRA_RPG_MAKER_MOD_GAME_ID = "rpgMakerModGameId"
         private const val RPG_MAKER_MOD_PREFS = "tyranor_rpgmaker_mod_state"
-        private const val GAME_OVERRIDES_PREFS = "tyranor_game_overrides"
         private const val PER_GAME_TOUCH_PAD_KEY = "touch_pad_config"
         private const val PER_GAME_TOUCH_PAD_PRESETS_KEY = "touch_pad_presets"
         private const val RPG_MAKER_MOD_CORE_ASSET = "__rpgmaker_mod_core.js"


### PR DESCRIPTION
### 背景
issue #30：在游戏内自定义触屏手柄虚拟键的布局。

### 功能
- 修改器 FAB →「键盘」→「进入键盘映射」进入编辑模式：拖拽、缩放（1%-200%）、透明、十字微调（4px）
- 布局按游戏持久化，横竖屏切换后位置稳定（坐标归一化）
- QWZX 键组作为整体单元移动 / 缩放 / 透明
- 预设：最多 10 个，支持保存当前布局 / 载入 / 重命名（≤12 字）/ 删除，按游戏保存
- 预览：FAB「键盘」页列出预设，支持只读预览（仅可退出）与一键载入
- 透明按钮在编辑中显示蓝色占位，保存后才隐藏

### 技术要点
- 坐标改为视口归一化（0..1），旧像素配置自动迁移
- 中心定位用 offsetWidth/offsetHeight，缩放 / 拖拽 / 微调不漂移
- 编辑 / 预览模式拦截触摸、鼠标、键盘输入，避免穿透到游戏；并隐藏 FAB 悬浮球保持模态
- 预设映射用 Object.create(null) 防原型污染；输入名称后强制收起软键盘
- Kotlin 桥新增 getPresets / savePresets（touch_pad_presets 键）

### 涉及文件
- engine/src/main/assets/__touch_pad.js（核心）
- engine/src/main/assets/__rpgmaker_mod_ui.js（FAB 键盘页）
- engine/src/main/java/com/core/tyrano/TyranoActivity.kt（预设持久化桥）
- app/.../PerGameSettingsStore.kt（touch_pad_config 字段）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增触屏手柄布局编辑器，支持拖拽、微调、缩放、透明度调整及恢复默认布局。
  - 支持按游戏保存和加载触屏手柄配置，并自动持久化。
  - 新增最多 10 个布局预设，可保存、载入、重命名、删除及预览。
  - 新增“键盘”设置页，提供手柄检测、编辑和预设管理功能。
  - 支持屏幕旋转和尺寸变化时自动调整手柄布局。
- **优化**
  - 配置异常时保留现有设置并提示。
  - 修正深浅色主题下搜索框文字颜色显示。
  - 优化游戏重命名输入框的文字样式。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->