### PR TITLE
fix(engine,scanner): 多线程防冻结/防写坏加固——KRKRCall 输入等待保险丝 + 插件解压单飞锁

### DIFF
--- a/app/src/main/java/com/tyranor/next/core/engine/plugin/EnginePluginBootstrap.kt
+++ b/app/src/main/java/com/tyranor/next/core/engine/plugin/EnginePluginBootstrap.kt
@@ -81,26 +81,44 @@ object EnginePluginBootstrap {
         }
     }
 
-    @Synchronized
+    /** 单飞锁：并发触发（快速重建/双入口）时仅一个线程执行解压，避免同目录交错写坏插件 */
+    private val provisionLock = Any()
+
     private fun provisionEngineIfNeeded(app: Context, spec: EngineSpec, requireEnabled: Boolean): Boolean {
+        if (resolveAlreadyInstalled(app, spec, requireEnabled)) return true
+        synchronized(provisionLock) {
+            // 双检：持锁后另一线程可能已完成安装
+            if (resolveAlreadyInstalled(app, spec, requireEnabled)) return true
+            return installNow(app, spec)
+        }
+    }
+
+    /** 已安装则按需刷新启用标记并返回 true。 */
+    private fun resolveAlreadyInstalled(app: Context, spec: EngineSpec, requireEnabled: Boolean): Boolean {
         val prefs = app.getSharedPreferences(EnginePrefs.APP_PREFS, Context.MODE_PRIVATE)
-        val state = installState(app, spec.engineId)
-        if (state == NativePluginInstallState.INSTALLED_ENABLED) {
-            markInstalled(prefs, spec, enabled = true)
-            return true
+        when (installState(app, spec.engineId)) {
+            NativePluginInstallState.INSTALLED_ENABLED -> {
+                markInstalled(prefs, spec, enabled = true)
+                return true
+            }
+            NativePluginInstallState.INSTALLED_DISABLED -> {
+                if (!requireEnabled) {
+                    markInstalled(prefs, spec, enabled = false)
+                    return true
+                }
+                markInstalled(prefs, spec, enabled = true)
+                return isReady(app, spec.engineId)
+            }
+            else -> return false
         }
-        if (!requireEnabled && state == NativePluginInstallState.INSTALLED_DISABLED) {
-            markInstalled(prefs, spec, enabled = false)
-            return true
-        }
-        if (requireEnabled && state == NativePluginInstallState.INSTALLED_DISABLED) {
-            markInstalled(prefs, spec, enabled = true)
-            return isReady(app, spec.engineId)
-        }
+    }
+
+    private fun installNow(app: Context, spec: EngineSpec): Boolean {
         return try {
             val target = currentDirFor(app, spec.engineId)
             if (target.exists()) target.deleteRecursively()
             extractPluginZip(app, spec.engineId, target)
+            val prefs = app.getSharedPreferences(EnginePrefs.APP_PREFS, Context.MODE_PRIVATE)
             markInstalled(prefs, spec, enabled = true)
             val ready = isReady(app, spec.engineId)
             if (ready) {

--- a/app/src/main/java/com/tyranor/next/core/engine/plugin/EnginePluginBootstrap.kt
+++ b/app/src/main/java/com/tyranor/next/core/engine/plugin/EnginePluginBootstrap.kt
@@ -131,7 +131,10 @@ object EnginePluginBootstrap {
         val prefs = app.getSharedPreferences(EnginePrefs.APP_PREFS, Context.MODE_PRIVATE)
         return try {
             val target = currentDirFor(app, spec.engineId)
-            if (target.exists()) target.deleteRecursively()
+            if (target.exists() && !target.deleteRecursively()) {
+                // 删除失败（可能部分删除）：中止安装，避免旧残留与解压产物混杂（CodeRabbit 意见）
+                throw IllegalStateException("cleanup failed for ${spec.engineId}")
+            }
             extractPluginZip(app, spec.engineId, target)
             // 先写标记再校验：installState 的 ENABLED 判定依赖 enabled 标记，须先标记才能读到就绪；
             // 目录缺必需文件会返回 INVALID（与标记无关），据此兜底回滚

--- a/app/src/main/java/com/tyranor/next/core/engine/plugin/EnginePluginBootstrap.kt
+++ b/app/src/main/java/com/tyranor/next/core/engine/plugin/EnginePluginBootstrap.kt
@@ -81,15 +81,29 @@ object EnginePluginBootstrap {
         }
     }
 
-    /** 单飞锁：并发触发（快速重建/双入口）时仅一个线程执行解压，避免同目录交错写坏插件 */
+    /** 单飞锁：并发触发（快速重建/双入口）时仅一个线程执行解压与状态写入，避免同目录交错写坏插件 */
     private val provisionLock = Any()
 
     private fun provisionEngineIfNeeded(app: Context, spec: EngineSpec, requireEnabled: Boolean): Boolean {
-        if (resolveAlreadyInstalled(app, spec, requireEnabled)) return true
+        // 锁外快速路径：纯读，不修改任何状态。若在此写 enabledKey，启动线程（requireEnabled=true）
+        // 与 MainActivity 后台预热线程（requireEnabled=false）并发时会互相覆盖标记（CodeRabbit 意见）
+        if (isInstalledReadOnly(app, spec, requireEnabled)) return true
         synchronized(provisionLock) {
-            // 双检：持锁后另一线程可能已完成安装
-            if (resolveAlreadyInstalled(app, spec, requireEnabled)) return true
-            return installNow(app, spec)
+            // 锁内完整路径：状态刷新 + 安装，写操作全部在锁内原子完成
+            return if (resolveAlreadyInstalled(app, spec, requireEnabled)) {
+                true
+            } else {
+                installNow(app, spec)
+            }
+        }
+    }
+
+    /** 纯读快速检查：已装且满足启用要求即视为就绪。不修改任何标记（写操作统一在锁内完成）。 */
+    private fun isInstalledReadOnly(app: Context, spec: EngineSpec, requireEnabled: Boolean): Boolean {
+        return when (installState(app, spec.engineId)) {
+            NativePluginInstallState.INSTALLED_ENABLED -> true
+            NativePluginInstallState.INSTALLED_DISABLED -> !requireEnabled
+            else -> false
         }
     }
 
@@ -114,20 +128,32 @@ object EnginePluginBootstrap {
     }
 
     private fun installNow(app: Context, spec: EngineSpec): Boolean {
+        val prefs = app.getSharedPreferences(EnginePrefs.APP_PREFS, Context.MODE_PRIVATE)
         return try {
             val target = currentDirFor(app, spec.engineId)
             if (target.exists()) target.deleteRecursively()
             extractPluginZip(app, spec.engineId, target)
-            val prefs = app.getSharedPreferences(EnginePrefs.APP_PREFS, Context.MODE_PRIVATE)
+            // 先写标记再校验：installState 的 ENABLED 判定依赖 enabled 标记，须先标记才能读到就绪；
+            // 目录缺必需文件会返回 INVALID（与标记无关），据此兜底回滚
             markInstalled(prefs, spec, enabled = true)
-            val ready = isReady(app, spec.engineId)
-            if (ready) {
-                android.util.Log.i(TAG, "provisioned native plugin: ${spec.engineId}")
-            } else {
-                android.util.Log.w(TAG, "provision ${spec.engineId} finished but validation failed")
+            if (!isReady(app, spec.engineId)) {
+                // 解压产物校验失败：回滚标记并清理目录，避免残留“已安装”元数据（CodeRabbit 意见）
+                clearInstalled(prefs, spec)
+                if (target.exists()) target.deleteRecursively()
+                android.util.Log.w(TAG, "provision ${spec.engineId} validation failed, rolled back")
+                return false
             }
-            ready
+            android.util.Log.i(TAG, "provisioned native plugin: ${spec.engineId}")
+            true
         } catch (t: Throwable) {
+            // 解压/清理中途异常：回滚元数据并清理残留目录，保证下次可干净重装（CodeRabbit 意见）
+            try {
+                clearInstalled(prefs, spec)
+                val target = currentDirFor(app, spec.engineId)
+                if (target.exists()) target.deleteRecursively()
+            } catch (_: Throwable) {
+                // 清理失败仅记录在日志，不覆盖原始异常
+            }
             android.util.Log.w(TAG, "provision ${spec.engineId} failed", t)
             false
         }
@@ -151,6 +177,13 @@ object EnginePluginBootstrap {
         prefs.edit()
             .putBoolean(spec.installedKey, true)
             .putBoolean(spec.enabledKey, enabled)
+            .apply()
+    }
+
+    private fun clearInstalled(prefs: SharedPreferences, spec: EngineSpec) {
+        prefs.edit()
+            .remove(spec.installedKey)
+            .remove(spec.enabledKey)
             .apply()
     }
 

--- a/engine/src/main/java/org/tvp/krkrsdl3/KRKRCall.java
+++ b/engine/src/main/java/org/tvp/krkrsdl3/KRKRCall.java
@@ -23,6 +23,7 @@ import com.core.engine.EngineThemeColors;
 import org.libsdl3.app.SDLActivity;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public class KRKRCall {
     /**
@@ -31,10 +32,17 @@ public class KRKRCall {
      * mInputResult/mInputResultCode 由 UI 线程写入、native 线程（WaitInputResult）读取，
      * 跨线程 happens-before 由 CountDownLatch.await/countDown 保证；加 volatile 双保险（ARM 弱内存模型）。
      */
-    private static AlertDialog mInputDialog = null;
-    private static volatile String mInputResult = "";
-    private static volatile int mInputResultCode = -1;
-    private static volatile CountDownLatch mInputLatch = new CountDownLatch(1);
+    private static final long WAIT_SLICE_MS = 200L;
+    /** 保险丝默认值：极端异常下（对话框既未显示也未被取消）最多阻塞 10 分钟后按取消返回，避免引擎永久冻结 */
+    static final long DEFAULT_MAX_WAIT_MS = 10L * 60L * 1000L;
+    // 非常量以便同包回归测试注入短时限（验证保险丝未被移除）；生产路径勿改
+    static volatile long maxWaitMs = DEFAULT_MAX_WAIT_MS;
+    // 以下四个字段包内可见（默认 private），仅供同包回归测试重置/注入状态
+    static AlertDialog mInputDialog = null;
+    static volatile String mInputResult = "";
+    static volatile int mInputResultCode = -1;
+    // 初始即为已触发态：无弹窗时的杂散 WaitInputResult 立即按取消返回，而非永久阻塞
+    static volatile CountDownLatch mInputLatch = new CountDownLatch(0);
 
     public static void ShowInputBox(String title, String prompt, String text, String[] buttons) {
         final Activity act = SDLActivity.getContext();
@@ -50,8 +58,12 @@ public class KRKRCall {
             @Override
             public void run() {
                 // 守卫：post 与执行之间 Activity 可能已被销毁（Home 键/系统回收），
-                // 避免 dialog.show() 在已销毁 Activity 上抛 WindowManager$BadTokenException 闪退
-                if (act.isFinishing() || act.isDestroyed()) return;
+                // 避免 dialog.show() 在已销毁 Activity 上抛 WindowManager$BadTokenException 闪退；
+                // 同时立即放行 native 等待方，不依赖 onDestroy 的时序兜底
+                if (act.isFinishing() || act.isDestroyed()) {
+                    latch.countDown();
+                    return;
+                }
                 // 主题色从 Launcher 传入的 Intent extras 读取（跟随启动器主题与深浅色）
                 final EngineThemeColors.Palette colors = EngineThemeColors.fromIntent(act.getIntent());
                 final float density = act.getResources().getDisplayMetrics().density;
@@ -216,12 +228,26 @@ public class KRKRCall {
 
     // 阻塞等待对话框关闭
     public static int WaitInputResult() {
-        try {
-            mInputLatch.await();
-        } catch (InterruptedException e) {
-            // 等待被中断（宿主销毁/系统回收）：恢复中断标记并按取消处理，不静默吞异常
-            Thread.currentThread().interrupt();
-            return -1;
+        final long startNs = System.nanoTime();
+        while (true) {
+            // 快照当前 latch：期间若出现新的 ShowInputBox，旧等待立即作废，避免等错对象导致无限挂起
+            final CountDownLatch latch = mInputLatch;
+            try {
+                if (latch.await(WAIT_SLICE_MS, TimeUnit.MILLISECONDS)) {
+                    break;
+                }
+            } catch (InterruptedException e) {
+                // 等待被中断（宿主销毁/系统回收）：恢复中断标记并按取消处理，不静默吞异常
+                Thread.currentThread().interrupt();
+                return -1;
+            }
+            if (mInputLatch != latch) {
+                return -1;
+            }
+            // 注意单位：nanoTime 差值为纳秒，maxWaitMs 为毫秒，必须经 TimeUnit 显式换算后比较
+            if (System.nanoTime() - startNs > TimeUnit.MILLISECONDS.toNanos(maxWaitMs)) {
+                return -1;
+            }
         }
         return mInputResultCode;
     }

--- a/engine/src/main/java/org/tvp/krkrsdl3/KRKRCall.java
+++ b/engine/src/main/java/org/tvp/krkrsdl3/KRKRCall.java
@@ -46,7 +46,14 @@ public class KRKRCall {
 
     public static void ShowInputBox(String title, String prompt, String text, String[] buttons) {
         final Activity act = SDLActivity.getContext();
-        if (act == null) return;
+        if (act == null) {
+            // 宿主未就绪：本次输入无法展示，替换为已触发 latch 立即放行 native 等待方（按取消返回），
+            // 而非让等待者悬置到保险丝时限才兜底
+            mInputResult = "";
+            mInputResultCode = -1;
+            mInputLatch = new CountDownLatch(0);
+            return;
+        }
 
         // 同步重置状态：先于 runOnUiThread，确保 native 线程 WaitInputResult 等待的是新 latch
         mInputResult = "";
@@ -234,7 +241,12 @@ public class KRKRCall {
             final CountDownLatch latch = mInputLatch;
             try {
                 if (latch.await(WAIT_SLICE_MS, TimeUnit.MILLISECONDS)) {
-                    break;
+                    // 触发的必须是当前 latch：若期间已被新一轮 ShowInputBox 替换，
+                    // 结果码可能已被重置/覆写而不可信，按取消返回而非上浮被污染的结果
+                    if (mInputLatch == latch) {
+                        return mInputResultCode;
+                    }
+                    return -1;
                 }
             } catch (InterruptedException e) {
                 // 等待被中断（宿主销毁/系统回收）：恢复中断标记并按取消处理，不静默吞异常
@@ -249,7 +261,6 @@ public class KRKRCall {
                 return -1;
             }
         }
-        return mInputResultCode;
     }
     // 获取结果
     public static String GetInputResult() {

--- a/engine/src/test/java/org/tvp/krkrsdl3/KRKRCallWaitInputResultTest.kt
+++ b/engine/src/test/java/org/tvp/krkrsdl3/KRKRCallWaitInputResultTest.kt
@@ -110,21 +110,24 @@ class KRKRCallWaitInputResultTest {
     fun resultFromSupersededDialogTreatedAsCancel() {
         val oldLatch = CountDownLatch(1)
         KRKRCall.mInputLatch = oldLatch
-        val pool = Executors.newSingleThreadExecutor()
-        try {
-            val future = pool.submit(java.util.concurrent.Callable { KRKRCall.WaitInputResult() })
-            // 让等待方快照 oldLatch 并进入 await
-            Thread.sleep(100)
-            // 新一轮 ShowInputBox 发起并已完成：替换 latch 并写入新结果
-            KRKRCall.mInputResult = "new input"
-            KRKRCall.mInputResultCode = 1
-            KRKRCall.mInputLatch = CountDownLatch(0)
-            // 旧对话框此刻才完成（迟滞回调）：触发旧 latch
-            oldLatch.countDown()
-            assertEquals("被取代对话框的结果不应上浮", -1, future.get(5, TimeUnit.SECONDS))
-        } finally {
-            pool.shutdownNow()
+        val result = IntArray(1)
+        val waiter = Thread { result[0] = KRKRCall.WaitInputResult() }
+        waiter.start()
+        // 有界等待等待线程进入 TIMED_WAITING（200ms await 切片），确认已快照 oldLatch，而非依赖固定 sleep
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (waiter.state != Thread.State.TIMED_WAITING && System.nanoTime() < deadline) {
+            Thread.sleep(5)
         }
+        assertTrue("等待线程应在有界时间内进入轮询等待，实际 ${waiter.state}", waiter.state == Thread.State.TIMED_WAITING)
+        // 新一轮 ShowInputBox 发起并已完成：替换 latch 并写入新结果
+        KRKRCall.mInputResult = "new input"
+        KRKRCall.mInputResultCode = 1
+        KRKRCall.mInputLatch = CountDownLatch(0)
+        // 旧对话框此刻才完成（迟滞回调）：触发旧 latch
+        oldLatch.countDown()
+        waiter.join(5_000)
+        assertTrue("等待线程应在有界时间内结束", !waiter.isAlive)
+        assertEquals("被取代对话框的结果不应上浮", -1, result[0])
     }
 
     /** 宿主销毁兜底：cancelPendingInput 必须解除 native 侧阻塞（onDestroy join 死锁回归）。 */

--- a/engine/src/test/java/org/tvp/krkrsdl3/KRKRCallWaitInputResultTest.kt
+++ b/engine/src/test/java/org/tvp/krkrsdl3/KRKRCallWaitInputResultTest.kt
@@ -1,0 +1,121 @@
+package org.tvp.krkrsdl3
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * C-1 回归护栏（audit/13 §二）：锁定 KRKRCall.WaitInputResult 的四条防冻结语义。
+ *
+ * 任一条被回退（初始 latch 改回未触发态 / 删掉 latch 作废检测 / 删掉保险丝 /
+ * 吞掉中断标记），对应用例将挂起直至 @Test(timeout) 超时失败，而非静默通过。
+ */
+class KRKRCallWaitInputResultTest {
+
+    @Before
+    fun resetStaticState() {
+        KRKRCall.mInputDialog = null
+        KRKRCall.mInputResult = ""
+        KRKRCall.mInputResultCode = -1
+        // 与生产初值一致：已触发态，杂散等待立即返回
+        KRKRCall.mInputLatch = CountDownLatch(0)
+        KRKRCall.maxWaitMs = KRKRCall.DEFAULT_MAX_WAIT_MS
+    }
+
+    @After
+    fun restoreFuse() {
+        KRKRCall.maxWaitMs = KRKRCall.DEFAULT_MAX_WAIT_MS
+    }
+
+    /** 无弹窗时的杂散等待必须立即按取消返回（初始 latch=已触发态）。回退为未触发态则本例挂死。 */
+    @Test(timeout = 5_000L)
+    fun strayWaitWithoutDialogReturnsCancelImmediately() {
+        val start = System.nanoTime()
+        assertEquals(-1, KRKRCall.WaitInputResult())
+        assertTrue("应立即返回而非阻塞", System.nanoTime() - start < TimeUnit.SECONDS.toNanos(2))
+    }
+
+    /** 等待期间出现新对话框（latch 被换）时，旧等待必须作废返回，而非等错对象无限挂起。 */
+    @Test(timeout = 10_000L)
+    fun staleWaiterInvalidatedWhenLatchReplaced() {
+        val stale = CountDownLatch(1)
+        KRKRCall.mInputLatch = stale
+        val pool = Executors.newSingleThreadExecutor()
+        try {
+            val future = pool.submit(java.util.concurrent.Callable { KRKRCall.WaitInputResult() })
+            // 让等待方至少进入一个 200ms 轮询切片
+            Thread.sleep(300)
+            // 模拟新一轮 ShowInputBox 已同步替换 latch 且该轮已完成（count=0）
+            KRKRCall.mInputLatch = CountDownLatch(0)
+            assertEquals("旧等待应作废并按取消返回", -1, future.get(5, TimeUnit.SECONDS))
+        } finally {
+            pool.shutdownNow()
+        }
+    }
+
+    /** 保险丝：孤儿等待（latch 永不触发且不被替换）最迟在时限后解锁。删除保险丝检查则本例挂死超时。 */
+    @Test(timeout = 10_000L)
+    fun fuseCapsOrphanWait() {
+        KRKRCall.maxWaitMs = 400L
+        KRKRCall.mInputLatch = CountDownLatch(1)
+        val start = System.nanoTime()
+        assertEquals(-1, KRKRCall.WaitInputResult())
+        val elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start)
+        assertTrue("应在保险丝时限附近返回，实际 ${elapsedMs}ms", elapsedMs in 300..9_000)
+    }
+
+    /** 中断路径：恢复中断标记并按取消返回，不吞异常不丢标记。 */
+    @Test(timeout = 5_000L)
+    fun interruptedWaitReturnsCancelAndRestoresFlag() {
+        KRKRCall.mInputLatch = CountDownLatch(1)
+        Thread.currentThread().interrupt()
+        try {
+            assertEquals(-1, KRKRCall.WaitInputResult())
+            assertTrue("中断标记应被恢复", Thread.interrupted())
+        } finally {
+            // 兜底清理，避免污染同线程后续用例
+            Thread.interrupted()
+        }
+    }
+
+    /** 正常路径：对话框完成（countDown + 写结果码）后等待方拿到结果码而非哨兵值。 */
+    @Test(timeout = 5_000L)
+    fun resultCodePropagatesAfterDialogCompletes() {
+        val latch = CountDownLatch(1)
+        KRKRCall.mInputLatch = latch
+        val pool = Executors.newSingleThreadExecutor()
+        try {
+            val future = pool.submit {
+                Thread.sleep(50)
+                KRKRCall.mInputResult = "input"
+                KRKRCall.mInputResultCode = 0
+                latch.countDown()
+                null
+            }
+            future.get(2, TimeUnit.SECONDS)
+            assertEquals(0, KRKRCall.WaitInputResult())
+        } finally {
+            pool.shutdownNow()
+        }
+    }
+
+    /** 宿主销毁兜底：cancelPendingInput 必须解除 native 侧阻塞（onDestroy join 死锁回归）。 */
+    @Test(timeout = 5_000L)
+    fun cancelPendingInputReleasesWaiter() {
+        KRKRCall.mInputLatch = CountDownLatch(1)
+        val pool = Executors.newSingleThreadExecutor()
+        try {
+            val future = pool.submit(java.util.concurrent.Callable { KRKRCall.WaitInputResult() })
+            Thread.sleep(100)
+            KRKRCall.cancelPendingInput()
+            assertEquals("销毁兜底应放行等待线程并按取消返回", -1, future.get(4, TimeUnit.SECONDS))
+        } finally {
+            pool.shutdownNow()
+        }
+    }
+}

--- a/engine/src/test/java/org/tvp/krkrsdl3/KRKRCallWaitInputResultTest.kt
+++ b/engine/src/test/java/org/tvp/krkrsdl3/KRKRCallWaitInputResultTest.kt
@@ -10,10 +10,11 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 /**
- * C-1 回归护栏（audit/13 §二）：锁定 KRKRCall.WaitInputResult 的四条防冻结语义。
+ * C-1 回归护栏（audit/13 §二）：锁定 KRKRCall.WaitInputResult 的防冻结语义。
  *
  * 任一条被回退（初始 latch 改回未触发态 / 删掉 latch 作废检测 / 删掉保险丝 /
- * 吞掉中断标记），对应用例将挂起直至 @Test(timeout) 超时失败，而非静默通过。
+ * 吞掉中断标记 / 被取代对话框的结果码上浮），对应用例将挂起直至 @Test(timeout)
+ * 超时失败或断言失败，而非静默通过。
  */
 class KRKRCallWaitInputResultTest {
 
@@ -99,6 +100,28 @@ class KRKRCallWaitInputResultTest {
             }
             future.get(2, TimeUnit.SECONDS)
             assertEquals(0, KRKRCall.WaitInputResult())
+        } finally {
+            pool.shutdownNow()
+        }
+    }
+
+    /** await 已被触发但期间 latch 被新一轮 ShowInputBox 替换：结果码已被重置/覆写，必须按取消返回，不得上浮被污染的结果。 */
+    @Test(timeout = 5_000L)
+    fun resultFromSupersededDialogTreatedAsCancel() {
+        val oldLatch = CountDownLatch(1)
+        KRKRCall.mInputLatch = oldLatch
+        val pool = Executors.newSingleThreadExecutor()
+        try {
+            val future = pool.submit(java.util.concurrent.Callable { KRKRCall.WaitInputResult() })
+            // 让等待方快照 oldLatch 并进入 await
+            Thread.sleep(100)
+            // 新一轮 ShowInputBox 发起并已完成：替换 latch 并写入新结果
+            KRKRCall.mInputResult = "new input"
+            KRKRCall.mInputResultCode = 1
+            KRKRCall.mInputLatch = CountDownLatch(0)
+            // 旧对话框此刻才完成（迟滞回调）：触发旧 latch
+            oldLatch.countDown()
+            assertEquals("被取代对话框的结果不应上浮", -1, future.get(5, TimeUnit.SECONDS))
         } finally {
             pool.shutdownNow()
         }

--- a/engine/src/test/java/org/tvp/krkrsdl3/KRKRCallWaitInputResultTest.kt
+++ b/engine/src/test/java/org/tvp/krkrsdl3/KRKRCallWaitInputResultTest.kt
@@ -112,22 +112,29 @@ class KRKRCallWaitInputResultTest {
         KRKRCall.mInputLatch = oldLatch
         val result = IntArray(1)
         val waiter = Thread { result[0] = KRKRCall.WaitInputResult() }
-        waiter.start()
-        // 有界等待等待线程进入 TIMED_WAITING（200ms await 切片），确认已快照 oldLatch，而非依赖固定 sleep
-        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
-        while (waiter.state != Thread.State.TIMED_WAITING && System.nanoTime() < deadline) {
-            Thread.sleep(5)
+        try {
+            waiter.start()
+            // 有界等待等待线程进入 TIMED_WAITING（200ms await 切片），确认已快照 oldLatch，而非依赖固定 sleep
+            val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+            while (waiter.state != Thread.State.TIMED_WAITING && System.nanoTime() < deadline) {
+                Thread.sleep(5)
+            }
+            assertTrue("等待线程应在有界时间内进入轮询等待，实际 ${waiter.state}", waiter.state == Thread.State.TIMED_WAITING)
+            // 新一轮 ShowInputBox 发起并已完成：替换 latch 并写入新结果
+            KRKRCall.mInputResult = "new input"
+            KRKRCall.mInputResultCode = 1
+            KRKRCall.mInputLatch = CountDownLatch(0)
+            // 旧对话框此刻才完成（迟滞回调）：触发旧 latch
+            oldLatch.countDown()
+            waiter.join(5_000)
+            assertTrue("等待线程应在有界时间内结束", !waiter.isAlive)
+            assertEquals("被取代对话框的结果不应上浮", -1, result[0])
+        } finally {
+            // 兜底：断言失败或测试线程被中断时也释放 waiter，避免非 daemon 子线程泄漏/阻塞 JVM 退出
+            oldLatch.countDown()
+            waiter.interrupt()
+            waiter.join(5_000)
         }
-        assertTrue("等待线程应在有界时间内进入轮询等待，实际 ${waiter.state}", waiter.state == Thread.State.TIMED_WAITING)
-        // 新一轮 ShowInputBox 发起并已完成：替换 latch 并写入新结果
-        KRKRCall.mInputResult = "new input"
-        KRKRCall.mInputResultCode = 1
-        KRKRCall.mInputLatch = CountDownLatch(0)
-        // 旧对话框此刻才完成（迟滞回调）：触发旧 latch
-        oldLatch.countDown()
-        waiter.join(5_000)
-        assertTrue("等待线程应在有界时间内结束", !waiter.isAlive)
-        assertEquals("被取代对话框的结果不应上浮", -1, result[0])
     }
 
     /** 宿主销毁兜底：cancelPendingInput 必须解除 native 侧阻塞（onDestroy join 死锁回归）。 */


### PR DESCRIPTION
## 修改内容

修复两处多线程并发缺陷：
1. **krkrsdl3 输入等待无限挂起**：KRKRCall.WaitInputResult() 之前对 CountDownLatch 无超时阻塞，宿主在输入弹窗未确认时被销毁会导致 latch 永不触发，native 线程永久阻塞，进而使 SDL 主循环卡死（后台耗电）。
2. **引擎插件解压写坏竞态**：EnginePluginBootstrap 之前仅 @Synchronized 串行化，仍存在并发入口（快速重建/双入口触发）先删后写同一 current/ 目录的交错窗口。

## 修改原因

对照上游 main 逐文件核对：两个文件均为未修复版本；封面下载原子性（.tmp + ATOMIC_MOVE）已由上游 CoverImageCache 架构天然解决，故不在本 PR 范围内。

## 主要改动

- **KRKRCall.java**：初始 latch 改已触发态（无弹窗杂散等待立即按取消返回）；UI 守卫早退补 countDown；WaitInputResult 重写为 200ms 分片轮询 + 「latch 被更新调用取代」作废检测 + 10 分钟保险丝（nanoTime 纳秒差值经 TimeUnit 显式换算后与毫秒时限比较）；状态字段包内可见 + maxWaitMs 非 final，供同包回归测试注入。
- **EnginePluginBootstrap.kt**：@Synchronized 改为 provisionLock 单飞锁 + 锁内双检，快路径仍 O(状态读取)；并发第二线程在锁内发现已装即返回，杜绝「同时 deleteRecursively + 交错解压」。
- **新增 KRKRCallWaitInputResultTest**（engine，6 例）：锁定防冻结四条语义（杂散等待立即返回 / latch 替换作废 / 保险丝封顶孤儿等待 / 中断恢复），全部带 @Test(timeout)，语义回退即超时失败。

## 测试情况

- [x] 已完成本地测试：:engine:testDebugUnitTest 与 :app:testDebugUnitTest 全绿（含新增 6 例）
- [x] 原有功能正常（既有测试无回归）
- [ ] 已在多个设备测试（真机回归待后续）

## 相关 Issue

无。此为本镜像（chenjiefeng2001/Tyranor-Next）回提上游的修复。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 优化插件安装与启动流程，避免并发重复安装，提升状态管理稳定性。
  - 插件安装失败或校验不通过时会自动清理并恢复状态。
  - 已安装但未启用的插件在启动时会自动启用，并确认其可用状态。
  - 输入等待支持取消、超时、中断及页面退出处理，避免应用长时间无响应。
  - 改善输入状态切换和待处理输入的稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->