### PR TITLE
feat(engine): Ren'Py 外置 APK 引擎多版本支持（issue #52）

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 | Ren'Py | `.rpa`、`game/script.rpy`、`game/options.rpy`、`renpy/` + `.rpy/.rpyc` | 外置 RenPy APK 模块 |
 
 内置 Web 运行环境同时支持部分以 `app.asar` 打包的 NW.js 游戏；启动时会根据归档内容进一步识别具体类型。
-Ren'Py 与 RPG Maker XP/VX/VX Ace/mkxp-z 当前通过外置 APK 模块运行：主 App 默认启用该能力，仅在引擎页检查目标模块是否已安装；未安装时引擎 item 显示打叉并提示下载安装。RPG Maker MV/MZ 属于 Web runtime，继续使用内置 Web 运行环境。
+Ren'Py 与 RPG Maker XP/VX/VX Ace/mkxp-z 当前通过外置 APK 模块运行：Ren'Py 支持 8.5 / 8.0.3 / 7.7.1 版本，可在单游戏设置中选择引擎版本；主 App 默认启用该能力，仅在引擎页检查目标模块是否已安装；未安装时引擎 item 显示打叉并提示下载安装。RPG Maker MV/MZ 属于 Web runtime，继续使用内置 Web 运行环境。
 
 ### 平台与文件要求
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,8 @@
     <queries>
         <package android:name="cyou.joiplay.runtime.rpgmaker" />
         <package android:name="cyou.joiplay.runtime.renpy.v8d4d1" />
+        <package android:name="cyou.joiplay.runtime.renpy.v7d7d1" />
+        <package android:name="cyou.joiplay.renpy" />
     </queries>
 
     <application

--- a/app/src/main/java/com/tyranor/next/core/engine/external/ExternalEngineLauncher.kt
+++ b/app/src/main/java/com/tyranor/next/core/engine/external/ExternalEngineLauncher.kt
@@ -23,13 +23,8 @@ object ExternalEngineLauncher {
             false
         }
 
-    fun launch(context: Context, request: ExternalEngineLaunchRequest): ExternalEngineLaunchResult {
-        val module = ExternalEngineModuleRegistry.moduleForEngine(request.game.engine)
-            ?: return ExternalEngineLaunchResult.failure(
-                "未配置 ${request.game.engine.displayName} 外置引擎模块",
-                "module_not_found",
-            )
-        if (request.gameDirectoryPath.isBlank()) {
+    fun launch(context: Context, module: ExternalEngineModule, request: ExternalEngineLaunchRequest): ExternalEngineLaunchResult {
+        if (module.requiresGameDirectoryPath && request.gameDirectoryPath.isBlank()) {
             return ExternalEngineLaunchResult.failure(
                 "无法解析 ${request.game.engine.displayName} 游戏目录真实路径，外置引擎模块无法启动",
                 "invalid_game_path",

--- a/app/src/main/java/com/tyranor/next/core/engine/external/ExternalEngineModule.kt
+++ b/app/src/main/java/com/tyranor/next/core/engine/external/ExternalEngineModule.kt
@@ -16,6 +16,9 @@ interface ExternalEngineModule {
     val supportedAliases: Set<String>
     val installUrl: String?
 
+    /** 是否需要解析游戏目录真实路径。独立插件（仅拉起插件主界面）可覆写为 false。 */
+    val requiresGameDirectoryPath: Boolean get() = true
+
     fun prepareForLaunch(context: Context, request: ExternalEngineLaunchRequest): ExternalEngineLaunchResult? = null
 
     fun buildLaunchIntent(request: ExternalEngineLaunchRequest): Intent

--- a/app/src/main/java/com/tyranor/next/core/engine/external/ExternalEngineModuleRegistry.kt
+++ b/app/src/main/java/com/tyranor/next/core/engine/external/ExternalEngineModuleRegistry.kt
@@ -29,6 +29,10 @@ object ExternalEngineModuleRegistry {
             else -> null
         }
 
+    /**
+     * 按内部别名查找模块。仅用于兼容历史扫描数据与测试；当前启动不走此路径——
+     * Ren'Py 按单游戏版本设置选模块，RPG Maker 直接读 ScanGame.externalModuleAlias。
+     */
     fun moduleForAlias(alias: String?): ExternalEngineModule? =
         modules.firstOrNull { it.supportsAlias(alias) }
 

--- a/app/src/main/java/com/tyranor/next/core/engine/external/ExternalEngineModuleRegistry.kt
+++ b/app/src/main/java/com/tyranor/next/core/engine/external/ExternalEngineModuleRegistry.kt
@@ -16,6 +16,10 @@ object ExternalEngineModuleRegistry {
     fun moduleForEngine(engine: EngineType): ExternalEngineModule? =
         modules.firstOrNull { it.engine == engine }
 
+    /** 某引擎的全部外置模块（如 Ren'Py 的 8.5/8.0.3/7.7.1），用于安装状态聚合。 */
+    fun modulesForEngine(engine: EngineType): List<ExternalEngineModule> =
+        modules.filter { it.engine == engine }
+
     /** 按 Ren'Py 版本（EngineSettingsStore 的 RENPY_* 常量）查找模块；auto/未知返回 null，由调用方回退默认。 */
     fun moduleForRenpyVersion(version: String?): ExternalEngineModule? =
         when (version?.trim()?.lowercase(Locale.ROOT)) {

--- a/app/src/main/java/com/tyranor/next/core/engine/external/ExternalEngineModuleRegistry.kt
+++ b/app/src/main/java/com/tyranor/next/core/engine/external/ExternalEngineModuleRegistry.kt
@@ -1,16 +1,29 @@
 package com.tyranor.next.core.engine.external
 
 import com.tyranor.next.core.engine.EngineType
+import com.tyranor.next.core.settings.EngineSettingsStore
+import java.util.Locale
 
 /** 外置 APK 引擎模块单一注册表。 */
 object ExternalEngineModuleRegistry {
     val modules: List<ExternalEngineModule> = listOf(
         RenPyExternalEngineModule,
+        RenPy80ExternalEngineModule,
+        RenPy77ExternalEngineModule,
         RpgMakerExternalEngineModule,
     )
 
     fun moduleForEngine(engine: EngineType): ExternalEngineModule? =
         modules.firstOrNull { it.engine == engine }
+
+    /** 按 Ren'Py 版本（EngineSettingsStore 的 RENPY_* 常量）查找模块；auto/未知返回 null，由调用方回退默认。 */
+    fun moduleForRenpyVersion(version: String?): ExternalEngineModule? =
+        when (version?.trim()?.lowercase(Locale.ROOT)) {
+            EngineSettingsStore.RENPY_85 -> RenPyExternalEngineModule
+            EngineSettingsStore.RENPY_803 -> RenPy80ExternalEngineModule
+            EngineSettingsStore.RENPY_77 -> RenPy77ExternalEngineModule
+            else -> null
+        }
 
     fun moduleForAlias(alias: String?): ExternalEngineModule? =
         modules.firstOrNull { it.supportsAlias(alias) }

--- a/app/src/main/java/com/tyranor/next/core/engine/external/ExternalEngineModuleRegistry.kt
+++ b/app/src/main/java/com/tyranor/next/core/engine/external/ExternalEngineModuleRegistry.kt
@@ -16,9 +16,13 @@ object ExternalEngineModuleRegistry {
     fun moduleForEngine(engine: EngineType): ExternalEngineModule? =
         modules.firstOrNull { it.engine == engine }
 
-    /** 某引擎的全部外置模块（如 Ren'Py 的 8.5/8.0.3/7.7.1），用于安装状态聚合。 */
-    fun modulesForEngine(engine: EngineType): List<ExternalEngineModule> =
-        modules.filter { it.engine == engine }
+    /** 解析某引擎实际生效的外置模块：Ren'Py 按版本（null/auto/未知 → 默认 8.5），其余引擎返回其唯一模块。 */
+    fun resolveModule(engine: EngineType, renpyVersion: String? = null): ExternalEngineModule? {
+        if (engine == EngineType.RENPY) {
+            return moduleForRenpyVersion(renpyVersion) ?: moduleForEngine(engine)
+        }
+        return moduleForEngine(engine)
+    }
 
     /** 按 Ren'Py 版本（EngineSettingsStore 的 RENPY_* 常量）查找模块；auto/未知返回 null，由调用方回退默认。 */
     fun moduleForRenpyVersion(version: String?): ExternalEngineModule? =

--- a/app/src/main/java/com/tyranor/next/core/engine/external/JoiPlayRuntimeJson.kt
+++ b/app/src/main/java/com/tyranor/next/core/engine/external/JoiPlayRuntimeJson.kt
@@ -1,0 +1,33 @@
+package com.tyranor.next.core.engine.external
+
+/** JoiPlay 外置模块共用的 JSON 转义与字段拼接工具（避免各引擎模块重复实现）。 */
+
+internal fun StringBuilder.appendJsonField(name: String, value: String) {
+    append('"')
+    append(escapeJson(name))
+    append("\":\"")
+    append(escapeJson(value))
+    append('"')
+}
+
+internal fun escapeJson(value: String): String = buildString {
+    value.forEach { char ->
+        when (char) {
+            '\\' -> append("\\\\")
+            '"' -> append("\\\"")
+            '\b' -> append("\\b")
+            '\u000C' -> append("\\f")
+            '\n' -> append("\\n")
+            '\r' -> append("\\r")
+            '\t' -> append("\\t")
+            else -> {
+                if (char.code < 0x20) {
+                    append("\\u")
+                    append(char.code.toString(16).padStart(4, '0'))
+                } else {
+                    append(char)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/tyranor/next/core/engine/external/RenPyExternalEngineModule.kt
+++ b/app/src/main/java/com/tyranor/next/core/engine/external/RenPyExternalEngineModule.kt
@@ -3,20 +3,28 @@ package com.tyranor.next.core.engine.external
 import android.content.Intent
 import com.tyranor.next.core.engine.EngineType
 
-/** JoiPlay Ren'Py Runtime 外置 APK 模块协议。 */
-object RenPyExternalEngineModule : ExternalEngineModule {
-    override val id: String = "renpy"
+/**
+ * Ren'Py 外置 APK 引擎模块家族（issue #52）。
+ *
+ * - Ren'Py 8.5 / 7.7.1 走 JoiPlay runtime 模块协议（`cyou.joiplay.runtime.renpy.run`），
+ *   两者仅包名不同，共享 [RenPyRuntimeModule] 的 intent 构造。
+ * - Ren'Py 8.0.3 是独立插件（`cyou.joiplay.renpy`），Manifest 无 runtime.run action，
+ *   只能通过 MAIN launcher 拉起插件主界面，由用户在插件内选择游戏（兼容方法）。
+ *
+ * 启动协议集中在模块文件内，UI / 扫描器不散落 package/action 字符串。
+ */
+
+/** JoiPlay Ren'Py Runtime 模块通用协议（runtime.run）。 */
+abstract class RenPyRuntimeModule(
+    override val id: String,
+    override val displayName: String,
+    override val packageName: String,
+    override val installUrl: String?,
+    override val defaultAlias: String,
+    override val supportedAliases: Set<String>,
+) : ExternalEngineModule {
     override val engine: EngineType = EngineType.RENPY
-    override val displayName: String = "RenPy 模块"
-    override val packageName: String = "cyou.joiplay.runtime.renpy.v8d4d1"
     override val action: String = "cyou.joiplay.runtime.renpy.run"
-    override val defaultAlias: String = "internal.renpy"
-    override val supportedAliases: Set<String> = setOf(
-        "external.renpy",
-        "internal.renpy8",
-    )
-    override val installUrl: String =
-        "https://github.com/Weiss-UltimateSavior/RinneMobile/releases/download/test/RenPy-Plugin.apk"
 
     override fun buildLaunchIntent(request: ExternalEngineLaunchRequest): Intent =
         Intent(action).setPackage(packageName).apply {
@@ -46,34 +54,44 @@ object RenPyExternalEngineModule : ExternalEngineModule {
             append('}')
         }
     }
-
-    private fun StringBuilder.appendJsonField(name: String, value: String) {
-        append('"')
-        append(escapeJson(name))
-        append("\":\"")
-        append(escapeJson(value))
-        append('"')
-    }
-
-    private fun escapeJson(value: String): String = buildString {
-        value.forEach { char ->
-            when (char) {
-                '\\' -> append("\\\\")
-                '"' -> append("\\\"")
-                '\b' -> append("\\b")
-                '\u000C' -> append("\\f")
-                '\n' -> append("\\n")
-                '\r' -> append("\\r")
-                '\t' -> append("\\t")
-                else -> {
-                    if (char.code < 0x20) {
-                        append("\\u")
-                        append(char.code.toString(16).padStart(4, '0'))
-                    } else {
-                        append(char)
-                    }
-                }
-            }
-        }
-    }
 }
+
+/** Ren'Py 8.5 runtime 模块（默认版本）。 */
+object RenPyExternalEngineModule : RenPyRuntimeModule(
+    id = "renpy85",
+    displayName = "Ren'Py 8.5",
+    packageName = "cyou.joiplay.runtime.renpy.v8d4d1",
+    installUrl = RENPY_RELEASE_BASE + "RenPy-Plugin-8.5.apk",
+    defaultAlias = "internal.renpy",
+    supportedAliases = setOf("external.renpy", "internal.renpy8"),
+)
+
+/** Ren'Py 7.7.1 runtime 模块（与 8.5 同协议，仅包名不同）。 */
+object RenPy77ExternalEngineModule : RenPyRuntimeModule(
+    id = "renpy77",
+    displayName = "Ren'Py 7.7.1",
+    packageName = "cyou.joiplay.runtime.renpy.v7d7d1",
+    installUrl = RENPY_RELEASE_BASE + "RenPy-Plugin-7.7.1.apk",
+    defaultAlias = "internal.renpy7",
+    supportedAliases = setOf("external.renpy7", "internal.renpy77"),
+)
+
+/** Ren'Py 8.0.3 独立插件（无 runtime.run，仅 MAIN launcher）。 */
+object RenPy80ExternalEngineModule : ExternalEngineModule {
+    override val id: String = "renpy80"
+    override val engine: EngineType = EngineType.RENPY
+    override val displayName: String = "Ren'Py 8.0.3"
+    override val packageName: String = "cyou.joiplay.renpy"
+    override val action: String = Intent.ACTION_MAIN
+    override val defaultAlias: String = "internal.renpy80"
+    override val supportedAliases: Set<String> = setOf("external.renpy80")
+    override val requiresGameDirectoryPath: Boolean = false
+    override val installUrl: String? = RENPY_RELEASE_BASE + "RenPy-Plugin-8.0.3.apk"
+
+    override fun buildLaunchIntent(request: ExternalEngineLaunchRequest): Intent =
+        Intent(action).addCategory(Intent.CATEGORY_LAUNCHER).setPackage(packageName)
+}
+
+/** Ren'Py 插件 release 下载地址（托管于 Tyranor-Next Releases）。 */
+private const val RENPY_RELEASE_BASE =
+    "https://github.com/Weiss-UltimateSavior/Tyranor-Next/releases/download/renpy-plugins/"

--- a/app/src/main/java/com/tyranor/next/core/engine/external/RpgMakerExternalEngineModule.kt
+++ b/app/src/main/java/com/tyranor/next/core/engine/external/RpgMakerExternalEngineModule.kt
@@ -211,34 +211,4 @@ object RpgMakerExternalEngineModule : ExternalEngineModule {
 
     private fun gameIdFor(folder: String, title: String): String =
         Integer.toHexString(folder.ifBlank { title }.hashCode())
-
-    private fun StringBuilder.appendJsonField(name: String, value: String) {
-        append('"')
-        append(escapeJson(name))
-        append("\":\"")
-        append(escapeJson(value))
-        append('"')
-    }
-
-    private fun escapeJson(value: String): String = buildString {
-        value.forEach { char ->
-            when (char) {
-                '\\' -> append("\\\\")
-                '"' -> append("\\\"")
-                '\b' -> append("\\b")
-                '\u000C' -> append("\\f")
-                '\n' -> append("\\n")
-                '\r' -> append("\\r")
-                '\t' -> append("\\t")
-                else -> {
-                    if (char.code < 0x20) {
-                        append("\\u")
-                        append(char.code.toString(16).padStart(4, '0'))
-                    } else {
-                        append(char)
-                    }
-                }
-            }
-        }
-    }
 }

--- a/app/src/main/java/com/tyranor/next/core/game/launch/EngineLauncher.kt
+++ b/app/src/main/java/com/tyranor/next/core/game/launch/EngineLauncher.kt
@@ -78,6 +78,10 @@ object EngineLauncher {
             if (module.requiresGameDirectoryPath && path == null) {
                 return "无法解析游戏目录（仅支持本地文件路径）"
             }
+            // 外置引擎同样需要「所有文件访问」权限才能读取游戏目录（SAF 授权对外置 APK 无效）
+            if (path != null) {
+                requestAllFilesAccessIfNeeded(context, game, path)?.let { return it }
+            }
             val result = ExternalEngineLauncher.launch(
                 context,
                 module,

--- a/app/src/main/java/com/tyranor/next/core/game/launch/EngineLauncher.kt
+++ b/app/src/main/java/com/tyranor/next/core/game/launch/EngineLauncher.kt
@@ -65,15 +65,25 @@ object EngineLauncher {
      *  [patchChoice] 为 Artemis 补丁确认弹窗（见 [needsArtemisPatchConfirm]）的选择结果。 */
     suspend fun launch(context: Context, game: ScanGame, patchChoice: ArtemisPatchChoice? = null): String? {
         val path = resolveGameDirectory(context, game)
-        if (path == null) {
-            return "无法解析游戏目录（仅支持本地文件路径）"
-        }
-        ExternalEngineModuleRegistry.moduleForEngine(game.engine)?.let { module ->
+        ExternalEngineModuleRegistry.moduleForEngine(game.engine)?.let { defaultModule ->
+            val module = if (game.engine == EngineType.RENPY) {
+                ExternalEngineModuleRegistry.moduleForRenpyVersion(
+                    PerGameSettingsStore.getStr(context, game.uri, PerGameSettingsStore.F_RENPY_VERSION)
+                        ?: EngineSettingsStore.getRenpyVersion(context),
+                ) ?: defaultModule
+            } else {
+                defaultModule
+            }
+            // 独立插件（如 Ren'Py 8.0.3）只需拉起插件主界面，不依赖游戏目录解析
+            if (module.requiresGameDirectoryPath && path == null) {
+                return "无法解析游戏目录（仅支持本地文件路径）"
+            }
             val result = ExternalEngineLauncher.launch(
                 context,
+                module,
                 ExternalEngineLaunchRequest(
                     game = game,
-                    gameDirectoryPath = path,
+                    gameDirectoryPath = path.orEmpty(),
                     launchTarget = game.launchTarget,
                 ),
             )
@@ -82,6 +92,9 @@ object EngineLauncher {
                 return null
             }
             return result.message ?: "启动 ${module.displayName} 失败"
+        }
+        if (path == null) {
+            return "无法解析游戏目录（仅支持本地文件路径）"
         }
         requestAllFilesAccessIfNeeded(context, game, path)?.let { return it }
         EnginePluginBootstrap.ensureForLaunch(context, game.engine)?.let { return it }

--- a/app/src/main/java/com/tyranor/next/core/game/launch/EngineLauncher.kt
+++ b/app/src/main/java/com/tyranor/next/core/game/launch/EngineLauncher.kt
@@ -66,20 +66,21 @@ object EngineLauncher {
     suspend fun launch(context: Context, game: ScanGame, patchChoice: ArtemisPatchChoice? = null): String? {
         val path = resolveGameDirectory(context, game)
         ExternalEngineModuleRegistry.moduleForEngine(game.engine)?.let { defaultModule ->
-            val module = if (game.engine == EngineType.RENPY) {
-                ExternalEngineModuleRegistry.moduleForRenpyVersion(
+            val module = ExternalEngineModuleRegistry.resolveModule(
+                game.engine,
+                if (game.engine == EngineType.RENPY) {
                     PerGameSettingsStore.getStr(context, game.uri, PerGameSettingsStore.F_RENPY_VERSION)
-                        ?: EngineSettingsStore.getRenpyVersion(context),
-                ) ?: defaultModule
-            } else {
-                defaultModule
-            }
+                        ?: EngineSettingsStore.getRenpyVersion(context)
+                } else {
+                    null
+                },
+            ) ?: defaultModule
             // 独立插件（如 Ren'Py 8.0.3）只需拉起插件主界面，不依赖游戏目录解析
             if (module.requiresGameDirectoryPath && path == null) {
                 return "无法解析游戏目录（仅支持本地文件路径）"
             }
-            // 外置引擎同样需要「所有文件访问」权限才能读取游戏目录（SAF 授权对外置 APK 无效）
-            if (path != null) {
+            // 需要目录解析的外置引擎同样要「所有文件访问」权限才能读取游戏目录（SAF 授权对外置 APK 无效）
+            if (module.requiresGameDirectoryPath && path != null) {
                 requestAllFilesAccessIfNeeded(context, game, path)?.let { return it }
             }
             val result = ExternalEngineLauncher.launch(

--- a/app/src/main/java/com/tyranor/next/core/game/model/ScanGame.kt
+++ b/app/src/main/java/com/tyranor/next/core/game/model/ScanGame.kt
@@ -16,7 +16,7 @@ data class ScanGame(
     val coverSource: String? = null,
     val vndbId: String? = null,
     val metadataTitle: String? = null,
-    /** 外置 APK 模块内部别名，例如 internal.renpy / internal.rpgmxp，用于保留同一引擎下的子运行时。 */
+    /** 外置 APK 模块内部别名（如 internal.rpgmxp），用于保留同一引擎下的子运行时；Ren'Py 由单游戏版本设置决定，不写该字段。 */
     val externalModuleAlias: String? = null,
     /** 用户通过“启动文件”手动指定的启动入口文件名（相对游戏目录）；null 表示自动。 */
     val launchFile: String? = null,

--- a/app/src/main/java/com/tyranor/next/core/game/scan/EngineScanner.kt
+++ b/app/src/main/java/com/tyranor/next/core/game/scan/EngineScanner.kt
@@ -894,7 +894,8 @@ object EngineScanner {
                 hasRenpyDir && (hasRpy || hasRpyc) -> 90
                 else -> 85
             }
-            return Detection(EngineType.RENPY, confidence, "[游戏目录]", "internal.renpy")
+            // Ren'Py 版本由单游戏设置选择，扫描不写死版本别名（避免误导为固定 8.5 模块）
+            return Detection(EngineType.RENPY, confidence, "[游戏目录]")
         }
         if (hasIndex) {
             return Detection(EngineType.WEB_OTHER, 70, "[游戏目录]")

--- a/app/src/main/java/com/tyranor/next/core/settings/EngineSettingsStore.kt
+++ b/app/src/main/java/com/tyranor/next/core/settings/EngineSettingsStore.kt
@@ -33,6 +33,9 @@ object EngineSettingsStore {
     const val KEY_ARTEMIS_ROTATE_SCREEN = "artemis_rotate_screen"
     const val KEY_ARTEMIS_AUTO_PATCH = "artemis_auto_patch"
 
+    // Ren'Py 应用级默认（外置模块版本选择）
+    const val KEY_RENPY_ENGINE_VERSION = "renpy_engine_version"
+
     // Tyrano 与 RPG Maker Web 共用同一套 WebView 宿主设置；启动链路按同一键读取。
     const val KEY_TYRANO_EXTERNAL_NETWORK = "tyrano_external_network"
     const val KEY_TYRANO_SCOPED_SAVE_DIR = "tyrano_scoped_save_dir"
@@ -60,6 +63,12 @@ object EngineSettingsStore {
     const val AUTO_PATCH_ASK = "ask"
     const val AUTO_PATCH_AUTO = "auto"
     const val AUTO_PATCH_OFF = "off"
+
+    // Ren'Py 版本取值常量
+    const val RENPY_AUTO = "auto"
+    const val RENPY_85 = "8.5"
+    const val RENPY_803 = "8.0.3"
+    const val RENPY_77 = "7.7.1"
 
     val KR_RENDER_PREF_KEYS = listOf(
         KEY_KR_RENDERER, KEY_KR_SOFTWARE_DRAW_THREAD, KEY_KR_SOFTWARE_COMPRESS_TEX,
@@ -195,6 +204,16 @@ object EngineSettingsStore {
         return if (v == AUTO_PATCH_AUTO || v == AUTO_PATCH_OFF) v else AUTO_PATCH_ASK
     }
     fun setArtAutoPatch(c: Context, v: String) = prefs(c).edit().putString(KEY_ARTEMIS_AUTO_PATCH, v).apply()
+
+    // ---------- Ren'Py ----------
+    fun getRenpyVersion(c: Context): String {
+        val v = prefs(c).getString(KEY_RENPY_ENGINE_VERSION, RENPY_AUTO)
+        return when (v) {
+            RENPY_85, RENPY_803, RENPY_77 -> v
+            else -> RENPY_AUTO
+        }
+    }
+    fun setRenpyVersion(c: Context, v: String) = prefs(c).edit().putString(KEY_RENPY_ENGINE_VERSION, v).apply()
 
     // ---------- Tyrano ----------
     fun isTyranoExternalNetwork(c: Context): Boolean = prefs(c).getBoolean(KEY_TYRANO_EXTERNAL_NETWORK, false)

--- a/app/src/main/java/com/tyranor/next/core/settings/PerGameSettingsStore.kt
+++ b/app/src/main/java/com/tyranor/next/core/settings/PerGameSettingsStore.kt
@@ -42,6 +42,9 @@ object PerGameSettingsStore {
     // RPG Maker MV/MZ
     const val F_RPG_MAKER_MOD_ENABLED = "rpg_maker_mod_enabled"
 
+    // Ren'Py（外置模块版本选择）
+    const val F_RENPY_VERSION = "renpy_engine_version"
+
     // ONS 子对象键
     const val ONS_KEY = "ons"
 

--- a/app/src/main/java/com/tyranor/next/ui/engine/EngineScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/engine/EngineScreen.kt
@@ -46,6 +46,7 @@ import com.tyranor.next.core.engine.external.ExternalEngineLauncher
 import com.tyranor.next.core.engine.external.ExternalEngineModule
 import com.tyranor.next.core.engine.external.ExternalEngineModuleRegistry
 import com.tyranor.next.core.game.launch.EngineLauncher
+import com.tyranor.next.core.settings.EngineSettingsStore
 import com.tyranor.next.theme.NavWhite
 import com.tyranor.next.ui.common.AppAlertDialog
 import com.tyranor.next.ui.common.glassNavBottomInset
@@ -90,6 +91,14 @@ fun EngineScreen(modifier: Modifier = Modifier) {
                 contentType = { "engine" },
             ) { engine ->
                 val module = ExternalEngineModuleRegistry.moduleForEngine(engine)
+                // 「去下载」按全局 Ren'Py 版本对应模块提供，避免恒指向 8.5
+                val downloadModule = if (engine == EngineType.RENPY) {
+                    ExternalEngineModuleRegistry.moduleForRenpyVersion(
+                        EngineSettingsStore.getRenpyVersion(context),
+                    ) ?: module
+                } else {
+                    module
+                }
                 val installed = module == null || externalInstallStates[engine] == true
                 EngineRow(
                     engine = engine,
@@ -97,7 +106,7 @@ fun EngineScreen(modifier: Modifier = Modifier) {
                     installed = installed,
                     onClick = {
                         if (module != null && !installed) {
-                            missingModule = module
+                            missingModule = downloadModule
                         }
                     },
                 )

--- a/app/src/main/java/com/tyranor/next/ui/engine/EngineScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/engine/EngineScreen.kt
@@ -229,6 +229,8 @@ private fun refreshExternalInstallStates(
     engines: List<EngineType>,
 ): Map<EngineType, Boolean> =
     engines.mapNotNull { engine ->
-        val module = ExternalEngineModuleRegistry.moduleForEngine(engine) ?: return@mapNotNull null
-        engine to ExternalEngineLauncher.isPackageInstalled(context, module)
+        val mods = ExternalEngineModuleRegistry.modulesForEngine(engine)
+        if (mods.isEmpty()) return@mapNotNull null
+        // 同一引擎有多个版本模块（如 Ren'Py 8.5/8.0.3/7.7.1）时，任一已装即视为可用
+        engine to mods.any { ExternalEngineLauncher.isPackageInstalled(context, it) }
     }.toMap()

--- a/app/src/main/java/com/tyranor/next/ui/engine/EngineScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/engine/EngineScreen.kt
@@ -92,13 +92,10 @@ fun EngineScreen(modifier: Modifier = Modifier) {
             ) { engine ->
                 val module = ExternalEngineModuleRegistry.moduleForEngine(engine)
                 // 「去下载」按全局 Ren'Py 版本对应模块提供，避免恒指向 8.5
-                val downloadModule = if (engine == EngineType.RENPY) {
-                    ExternalEngineModuleRegistry.moduleForRenpyVersion(
-                        EngineSettingsStore.getRenpyVersion(context),
-                    ) ?: module
-                } else {
-                    module
-                }
+                val downloadModule = ExternalEngineModuleRegistry.resolveModule(
+                    engine,
+                    EngineSettingsStore.getRenpyVersion(context),
+                ) ?: module
                 val installed = module == null || externalInstallStates[engine] == true
                 EngineRow(
                     engine = engine,
@@ -238,8 +235,11 @@ private fun refreshExternalInstallStates(
     engines: List<EngineType>,
 ): Map<EngineType, Boolean> =
     engines.mapNotNull { engine ->
-        val mods = ExternalEngineModuleRegistry.modulesForEngine(engine)
-        if (mods.isEmpty()) return@mapNotNull null
-        // 同一引擎有多个版本模块（如 Ren'Py 8.5/8.0.3/7.7.1）时，任一已装即视为可用
-        engine to mods.any { ExternalEngineLauncher.isPackageInstalled(context, it) }
+        // 安装状态与下载/启动一致：Ren'Py 按全局版本解析目标模块（而非「任一版本已装」），
+        // 保证全局选 8.0.3 而仅装 8.5 时正确显示未安装并允许下载
+        val module = ExternalEngineModuleRegistry.resolveModule(
+            engine,
+            EngineSettingsStore.getRenpyVersion(context),
+        ) ?: return@mapNotNull null
+        engine to ExternalEngineLauncher.isPackageInstalled(context, module)
     }.toMap()

--- a/app/src/main/java/com/tyranor/next/ui/settings/EngineSettingsMenuActivity.kt
+++ b/app/src/main/java/com/tyranor/next/ui/settings/EngineSettingsMenuActivity.kt
@@ -159,4 +159,5 @@ enum class EngineSettingsKind(val title: String, @param:DrawableRes val iconRes:
     ARTEMIS("Artemis引擎设置", R.drawable.ic_settings_engine),
     RPG_MAKER("RPG Maker引擎设置", R.drawable.ic_settings_engine),
     TYRANO("Tyrano引擎设置", R.drawable.ic_settings_engine),
+    RENPY("Ren'Py引擎设置", R.drawable.ic_settings_engine),
 }

--- a/app/src/main/java/com/tyranor/next/ui/settings/PerGameSettingsScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/settings/PerGameSettingsScreen.kt
@@ -69,6 +69,7 @@ fun PerGameSettingsScreen(game: ScanGame) {
     var artVersion by remember { mutableStateOf(PerGameSettingsStore.getStr(ctx, gid, PerGameSettingsStore.F_ART_VERSION)) }
     var artRotate by remember { mutableStateOf(PerGameSettingsStore.getBool(ctx, gid, PerGameSettingsStore.F_ART_ROTATE)) }
     var artPatch by remember { mutableStateOf(PerGameSettingsStore.getStr(ctx, gid, PerGameSettingsStore.F_ART_PATCH)) }
+    var renpyVersion by remember { mutableStateOf(PerGameSettingsStore.getStr(ctx, gid, PerGameSettingsStore.F_RENPY_VERSION)) }
 
     val onsOverride = remember { mutableStateOf(PerGameSettingsStore.loadOnsOverride(ctx, gid) ?: JSONObject()) }
     var onsScoped by remember { mutableStateOf(onsBool(onsOverride.value, "scopedsavedir")) }
@@ -107,6 +108,7 @@ fun PerGameSettingsScreen(game: ScanGame) {
     val globalTyExternal = EngineSettingsStore.isTyranoExternalNetwork(ctx)
     val globalTyScoped = EngineSettingsStore.isTyranoScopedSaveDir(ctx)
     val globalRpgMakerMod = EngineSettingsStore.isRpgMakerModEnabled(ctx)
+    val globalRenpyVersion = EngineSettingsStore.getRenpyVersion(ctx)
 
     val isSdl3 = (krKernel ?: globalKrKernel) == EngineSettingsStore.KERNEL_KRKRSDL3
     val globalRenderer = configuredGlobalRenderer.ifEmpty {
@@ -135,6 +137,7 @@ fun PerGameSettingsScreen(game: ScanGame) {
         PerGameSettingsStore.setStr(ctx, gid, PerGameSettingsStore.F_ART_VERSION, artVersion)
         PerGameSettingsStore.setBool(ctx, gid, PerGameSettingsStore.F_ART_ROTATE, artRotate)
         PerGameSettingsStore.setStr(ctx, gid, PerGameSettingsStore.F_ART_PATCH, artPatch)
+        PerGameSettingsStore.setStr(ctx, gid, PerGameSettingsStore.F_RENPY_VERSION, renpyVersion)
         val onsObj = JSONObject()
         putIfNotNull(onsObj, "scopedsavedir", onsScoped)
         putIfNotNull(onsObj, "strechfull", onsStretch)
@@ -258,8 +261,9 @@ fun PerGameSettingsScreen(game: ScanGame) {
                     }
                     EngineType.RENPY -> item {
                         SectionCard("Ren'Py") {
+                            OverrideChoice("引擎版本", RENPY_VERSION_MAP2, globalRenpyVersion, renpyVersion) { renpyVersion = it }
                             Text(
-                                "Ren'Py 使用外置 APK 引擎模块，模块安装后默认启用；当前没有可由主应用覆盖的单游戏设置。",
+                                "Ren'Py 使用外置 APK 引擎模块，按指定版本打开对应的插件；模块安装后默认启用。",
                                 style = MaterialTheme.typography.bodyMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 10.dp),
@@ -421,6 +425,12 @@ private val ART_VERSION_MAP2 = mapOf(
     EngineSettingsStore.ART_ENGINE_V1 to "V1",
     EngineSettingsStore.ART_ENGINE_V2 to "V2",
     EngineSettingsStore.ART_ENGINE_V3 to "V3",
+)
+private val RENPY_VERSION_MAP2 = mapOf(
+    EngineSettingsStore.RENPY_AUTO to "自动",
+    EngineSettingsStore.RENPY_85 to "8.5",
+    EngineSettingsStore.RENPY_803 to "8.0.3",
+    EngineSettingsStore.RENPY_77 to "7.7.1",
 )
 private val ART_PATCH_MAP2 = mapOf(
     EngineSettingsStore.AUTO_PATCH_ASK to "启动时询问",

--- a/app/src/main/java/com/tyranor/next/ui/settings/PerGameSettingsScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/settings/PerGameSettingsScreen.kt
@@ -262,6 +262,14 @@ fun PerGameSettingsScreen(game: ScanGame) {
                     EngineType.RENPY -> item {
                         SectionCard("Ren'Py") {
                             OverrideChoice("引擎版本", RENPY_VERSION_MAP2, globalRenpyVersion, renpyVersion) { renpyVersion = it }
+                            if ((renpyVersion ?: globalRenpyVersion) == EngineSettingsStore.RENPY_803) {
+                                Text(
+                                    "8.0.3 为独立插件：启动后将打开插件主界面，请在插件内手动选择游戏。",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 6.dp),
+                                )
+                            }
                             Text(
                                 "Ren'Py 使用外置 APK 引擎模块，按指定版本打开对应的插件；模块安装后默认启用。",
                                 style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/java/com/tyranor/next/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/settings/SettingsScreen.kt
@@ -407,6 +407,7 @@ internal fun EngineSettingsDetailScreen(kind: EngineSettingsKind) {
     var tyExternal by remember { mutableStateOf(EngineSettingsStore.isTyranoExternalNetwork(ctx)) }
     var tyScoped by remember { mutableStateOf(EngineSettingsStore.isTyranoScopedSaveDir(ctx)) }
     var rpgMakerMod by remember { mutableStateOf(EngineSettingsStore.isRpgMakerModEnabled(ctx)) }
+    var renpyVersion by remember { mutableStateOf(EngineSettingsStore.getRenpyVersion(ctx)) }
 
     val fontLauncher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
         if (uri != null) {
@@ -442,6 +443,7 @@ internal fun EngineSettingsDetailScreen(kind: EngineSettingsKind) {
         EngineSettingsStore.setTyranoExternalNetwork(ctx, tyExternal)
         EngineSettingsStore.setTyranoScopedSaveDir(ctx, tyScoped)
         EngineSettingsStore.setRpgMakerModEnabled(ctx, rpgMakerMod)
+        EngineSettingsStore.setRenpyVersion(ctx, renpyVersion)
     }
 
     MiuixSettingsTheme {
@@ -478,7 +480,7 @@ internal fun EngineSettingsDetailScreen(kind: EngineSettingsKind) {
                 kind,
                 krVersion, krKernel, krScoped, krFont, krForceFont, krRenderer, krDrawThread,
                 krSwCompress, krOglCompress, krMem, krTexsize, krAccurate, krFps, isSdl3, krIs134126,
-                ons, artVersion, artRotate, artPatch, tyExternal, tyScoped, rpgMakerMod, fontLauncher,
+                ons, artVersion, artRotate, artPatch, tyExternal, tyScoped, rpgMakerMod, renpyVersion, fontLauncher,
                 topInset = innerPadding.calculateTopPadding(),
                 onKrVersion = { krVersion = it },
                 onKrKernel = { krKernel = it },
@@ -500,6 +502,7 @@ internal fun EngineSettingsDetailScreen(kind: EngineSettingsKind) {
                 onTyExternal = { tyExternal = it },
                 onTyScoped = { tyScoped = it },
                 onRpgMakerMod = { rpgMakerMod = it },
+                onRenpyVersion = { renpyVersion = it },
             )
         }
     }
@@ -546,7 +549,7 @@ private fun LazyListPlaceholder(
     krRenderer: String, krDrawThread: String, krSwCompress: String, krOglCompress: String,
     krMem: String, krTexsize: String, krAccurate: String, krFps: String, isSdl3: Boolean, krIs134126: Boolean,
     ons: EngineSettingsStore.Ons, artVersion: String, artRotate: Boolean, artPatch: String,
-    tyExternal: Boolean, tyScoped: Boolean, rpgMakerMod: Boolean, fontLauncher: FontPickerLauncher,
+    tyExternal: Boolean, tyScoped: Boolean, rpgMakerMod: Boolean, renpyVersion: String, fontLauncher: FontPickerLauncher,
     topInset: Dp,
     onKrVersion: (String) -> Unit, onKrKernel: (String) -> Unit, onKrScoped: (Boolean) -> Unit,
     onKrForceFont: (Boolean) -> Unit, onKrRenderer: (String) -> Unit, onKrDrawThread: (String) -> Unit,
@@ -555,6 +558,7 @@ private fun LazyListPlaceholder(
     onResetKrFont: () -> Unit, onOns: (EngineSettingsStore.Ons) -> Unit,
     onArtVersion: (String) -> Unit, onArtRotate: (Boolean) -> Unit, onArtPatch: (String) -> Unit,
     onTyExternal: (Boolean) -> Unit, onTyScoped: (Boolean) -> Unit, onRpgMakerMod: (Boolean) -> Unit,
+    onRenpyVersion: (String) -> Unit,
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize().padding(horizontal = 12.dp),
@@ -646,6 +650,21 @@ private fun LazyListPlaceholder(
                 SwitchPreference(title = "允许加载外部网络资源", checked = tyExternal, onCheckedChange = onTyExternal)
                 SwitchPreference(title = "独立存档目录", checked = tyScoped, onCheckedChange = onTyScoped)
                 SwitchPreference(title = "游戏修改器", checked = rpgMakerMod, onCheckedChange = onRpgMakerMod)
+            }
+        }
+
+        if (kind == EngineSettingsKind.RENPY) item {
+            EngineCard("Ren'Py") {
+                DropdownRow("引擎版本", RENPY_VERSION_MAP, renpyVersion, onRenpyVersion)
+                Text(
+                    if (renpyVersion == EngineSettingsStore.RENPY_803)
+                        "8.0.3 为独立插件：启动后将打开插件主界面，请在插件内手动选择游戏。"
+                    else
+                        "Ren'Py 使用外置 APK 引擎模块，按指定版本打开对应的插件。",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MiuixTheme.colorScheme.onBackground,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
             }
         }
 
@@ -825,6 +844,12 @@ private val ART_VERSION_MAP = listOf(
     EngineSettingsStore.ART_ENGINE_V1 to "V1",
     EngineSettingsStore.ART_ENGINE_V2 to "V2",
     EngineSettingsStore.ART_ENGINE_V3 to "V3",
+)
+private val RENPY_VERSION_MAP = listOf(
+    EngineSettingsStore.RENPY_AUTO to "自动",
+    EngineSettingsStore.RENPY_85 to "8.5",
+    EngineSettingsStore.RENPY_803 to "8.0.3",
+    EngineSettingsStore.RENPY_77 to "7.7.1",
 )
 private val ART_PATCH_MAP = listOf(
     EngineSettingsStore.AUTO_PATCH_ASK to "启动时询问",

--- a/app/src/test/java/com/tyranor/next/core/engine/external/ExternalEngineModuleRegistryTest.kt
+++ b/app/src/test/java/com/tyranor/next/core/engine/external/ExternalEngineModuleRegistryTest.kt
@@ -1,6 +1,10 @@
 package com.tyranor.next.core.engine.external
 
+import android.content.Intent
 import com.tyranor.next.core.engine.EngineType
+import com.tyranor.next.core.settings.EngineSettingsStore
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -13,7 +17,28 @@ class ExternalEngineModuleRegistryTest {
         assertSame(RenPyExternalEngineModule, ExternalEngineModuleRegistry.moduleForAlias("external.renpy"))
         assertSame(RenPyExternalEngineModule, ExternalEngineModuleRegistry.moduleForAlias(RenPyExternalEngineModule.packageName))
         assertTrue(ExternalEngineModuleRegistry.isExternalEngine(EngineType.RENPY))
-        assertTrue(RenPyExternalEngineModule.installUrl.orEmpty().endsWith("/RenPy-Plugin.apk"))
+        assertTrue(RenPyExternalEngineModule.installUrl.orEmpty().endsWith("/RenPy-Plugin-8.5.apk"))
+    }
+
+    @Test
+    fun resolvesRenPyVersions() {
+        assertSame(RenPyExternalEngineModule, ExternalEngineModuleRegistry.moduleForRenpyVersion(EngineSettingsStore.RENPY_85))
+        assertSame(RenPy80ExternalEngineModule, ExternalEngineModuleRegistry.moduleForRenpyVersion(EngineSettingsStore.RENPY_803))
+        assertSame(RenPy77ExternalEngineModule, ExternalEngineModuleRegistry.moduleForRenpyVersion(EngineSettingsStore.RENPY_77))
+        assertNull(ExternalEngineModuleRegistry.moduleForRenpyVersion(EngineSettingsStore.RENPY_AUTO))
+        assertNull(ExternalEngineModuleRegistry.moduleForRenpyVersion("unknown"))
+        assertNull(ExternalEngineModuleRegistry.moduleForRenpyVersion(""))
+        assertSame(RenPyExternalEngineModule, ExternalEngineModuleRegistry.moduleForRenpyVersion(" 8.5 "))
+    }
+
+    @Test
+    fun renpyVersionModuleProtocols() {
+        assertTrue(RenPy80ExternalEngineModule.installUrl.orEmpty().endsWith("/RenPy-Plugin-8.0.3.apk"))
+        assertTrue(RenPy77ExternalEngineModule.installUrl.orEmpty().endsWith("/RenPy-Plugin-7.7.1.apk"))
+        assertEquals("cyou.joiplay.runtime.renpy.run", RenPy77ExternalEngineModule.action)
+        assertEquals("cyou.joiplay.runtime.renpy.v7d7d1", RenPy77ExternalEngineModule.packageName)
+        assertEquals("cyou.joiplay.renpy", RenPy80ExternalEngineModule.packageName)
+        assertEquals(Intent.ACTION_MAIN, RenPy80ExternalEngineModule.action)
     }
 
     @Test

--- a/app/src/test/java/com/tyranor/next/core/engine/external/ExternalEngineModuleRegistryTest.kt
+++ b/app/src/test/java/com/tyranor/next/core/engine/external/ExternalEngineModuleRegistryTest.kt
@@ -33,12 +33,17 @@ class ExternalEngineModuleRegistryTest {
     }
 
     @Test
-    fun modulesForEngineAggregatesVersionModules() {
-        val renpy = ExternalEngineModuleRegistry.modulesForEngine(EngineType.RENPY)
-        assertEquals(3, renpy.size)
-        assertEquals(setOf("renpy85", "renpy80", "renpy77"), renpy.map { it.id }.toSet())
-        assertEquals(1, ExternalEngineModuleRegistry.modulesForEngine(EngineType.RPGMAKER).size)
-        assertEquals(0, ExternalEngineModuleRegistry.modulesForEngine(EngineType.KIRIKIRI).size)
+    fun resolveModulePicksVersionTargetForRenpy() {
+        // 全局/生效版本决定 Ren'Py 目标模块（而非「任一版本已装」），与启动/下载一致
+        assertSame(RenPy80ExternalEngineModule, ExternalEngineModuleRegistry.resolveModule(EngineType.RENPY, EngineSettingsStore.RENPY_803))
+        assertSame(RenPy77ExternalEngineModule, ExternalEngineModuleRegistry.resolveModule(EngineType.RENPY, EngineSettingsStore.RENPY_77))
+        assertSame(RenPyExternalEngineModule, ExternalEngineModuleRegistry.resolveModule(EngineType.RENPY, EngineSettingsStore.RENPY_85))
+        assertSame(RenPyExternalEngineModule, ExternalEngineModuleRegistry.resolveModule(EngineType.RENPY, EngineSettingsStore.RENPY_AUTO))
+        assertSame(RenPyExternalEngineModule, ExternalEngineModuleRegistry.resolveModule(EngineType.RENPY, null))
+        assertSame(RenPyExternalEngineModule, ExternalEngineModuleRegistry.resolveModule(EngineType.RENPY, "unknown"))
+        // 其余引擎返回其唯一模块，忽略版本
+        assertSame(RpgMakerExternalEngineModule, ExternalEngineModuleRegistry.resolveModule(EngineType.RPGMAKER, EngineSettingsStore.RENPY_803))
+        assertNull(ExternalEngineModuleRegistry.resolveModule(EngineType.KIRIKIRI))
     }
 
     @Test

--- a/app/src/test/java/com/tyranor/next/core/engine/external/ExternalEngineModuleRegistryTest.kt
+++ b/app/src/test/java/com/tyranor/next/core/engine/external/ExternalEngineModuleRegistryTest.kt
@@ -32,6 +32,15 @@ class ExternalEngineModuleRegistryTest {
     }
 
     @Test
+    fun modulesForEngineAggregatesVersionModules() {
+        val renpy = ExternalEngineModuleRegistry.modulesForEngine(EngineType.RENPY)
+        assertEquals(3, renpy.size)
+        assertEquals(setOf("renpy85", "renpy80", "renpy77"), renpy.map { it.id }.toSet())
+        assertEquals(1, ExternalEngineModuleRegistry.modulesForEngine(EngineType.RPGMAKER).size)
+        assertEquals(0, ExternalEngineModuleRegistry.modulesForEngine(EngineType.KIRIKIRI).size)
+    }
+
+    @Test
     fun renpyVersionModuleProtocols() {
         assertTrue(RenPy80ExternalEngineModule.installUrl.orEmpty().endsWith("/RenPy-Plugin-8.0.3.apk"))
         assertTrue(RenPy77ExternalEngineModule.installUrl.orEmpty().endsWith("/RenPy-Plugin-7.7.1.apk"))

--- a/app/src/test/java/com/tyranor/next/core/engine/external/ExternalEngineModuleRegistryTest.kt
+++ b/app/src/test/java/com/tyranor/next/core/engine/external/ExternalEngineModuleRegistryTest.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import com.tyranor.next.core.engine.EngineType
 import com.tyranor.next.core.settings.EngineSettingsStore
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
@@ -48,6 +49,18 @@ class ExternalEngineModuleRegistryTest {
         assertEquals("cyou.joiplay.runtime.renpy.v7d7d1", RenPy77ExternalEngineModule.packageName)
         assertEquals("cyou.joiplay.renpy", RenPy80ExternalEngineModule.packageName)
         assertEquals(Intent.ACTION_MAIN, RenPy80ExternalEngineModule.action)
+    }
+
+    @Test
+    fun runtimeVersionsRequireGameDirectoryButStandaloneDoesNot() {
+        assertTrue(RenPyExternalEngineModule.requiresGameDirectoryPath)
+        assertTrue(RenPy77ExternalEngineModule.requiresGameDirectoryPath)
+        assertFalse(RenPy80ExternalEngineModule.requiresGameDirectoryPath)
+        // 版本选择链路：每游戏版本 → 对应模块 → 是否依赖目录解析
+        assertSame(RenPy77ExternalEngineModule, ExternalEngineModuleRegistry.moduleForRenpyVersion(EngineSettingsStore.RENPY_77))
+        assertTrue(ExternalEngineModuleRegistry.moduleForRenpyVersion(EngineSettingsStore.RENPY_77)!!.requiresGameDirectoryPath)
+        assertSame(RenPy80ExternalEngineModule, ExternalEngineModuleRegistry.moduleForRenpyVersion(EngineSettingsStore.RENPY_803))
+        assertFalse(ExternalEngineModuleRegistry.moduleForRenpyVersion(EngineSettingsStore.RENPY_803)!!.requiresGameDirectoryPath)
     }
 
     @Test


### PR DESCRIPTION
### 背景
issue #52：Ren'Py 外置 APK 模块此前仅支持 8.5（cyou.joiplay.runtime.renpy.v8d4d1），需兼容 8.0.3 与 7.7.1。

### 功能
- Ren'Py 模块拆分为多版本：
  - 8.5（v8d4d1）与 7.7.1（v7d7d1）走 JoiPlay runtime 协议（cyou.joiplay.runtime.renpy.run），仅包名不同
  - 8.0.3（cyou.joiplay.renpy）为独立插件，无 runtime.run action，走 MAIN 拉起插件主界面（兼容方法，需在插件内选游戏）
- 单游戏设置新增「引擎版本」选择（自动 / 8.5 / 8.0.3 / 7.7.1），镜像 KRKR 的每游戏 ?: 全局模式
- 全局设置页新增「Ren'Py 引擎设置」入口，可设全局默认版本
- 启动链路按生效版本选对应模块（auto/未知回退 8.5）

### 关键修复
- 外置分支（Ren'Py/RPGM）启动前同样引导「所有文件访问」权限，未授权设备不再静默失败
- 引擎页 Ren'Py 安装状态改为「任一版本模块已装即算可用」；「去下载」按全局版本选对应模块，不再恒指 8.5
- 8.0.3 选中时 UI 明确提示「独立插件需在插件内手动选游戏」
- 扫描不再为 Ren'Py 写死版本别名（internal.renpy），消除按 alias 路由误选 8.5 的隐患

### 技术要点
- 抽取 RenPyRuntimeModule 基类 + JoiPlayRuntimeJson 共享 JSON 工具，消除 RenPy/RpgMaker 重复代码
- ExternalEngineLauncher.launch 改显式传模块；新增 requiresGameDirectoryPath（独立插件不依赖目录解析）
- 新增 EngineSettingsStore.get/setRenpyVersion、PerGameSettingsStore.F_RENPY_VERSION
- Manifest 补充 v7d7d1 / cyou.joiplay.renpy 包可见性

### 涉及文件（18）
- core/engine/external/*（模块拆分、注册表、启动器、共享 JSON）
- core/game/launch/EngineLauncher.kt、core/game/scan/EngineScanner.kt、core/game/model/ScanGame.kt
- core/settings/EngineSettingsStore.kt、PerGameSettingsStore.kt
- ui/engine/EngineScreen.kt、ui/settings/*（全局与单游戏设置）
- AndroidManifest.xml、README.md、测试

### 备注/后续
- installUrl 指向 Tyranor-Next Releases 的 renpy-plugins tag，需上传 8.5 / 8.0.3 / 7.7.1 三个插件 APK
- 8.0.3 / 7.7.1 插件实机拉起行为建议真机验证


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增 Ren’Py 8.5、8.0.3 和 7.7.1 外置引擎支持。
  - 支持在全局引擎设置及单个游戏设置中选择 Ren’Py 版本。
  - 优化外置引擎安装、检测与启动流程，适配不同版本的启动方式。
  - 新增 Ren’Py 引擎设置入口及版本说明；使用 8.0.3 时可在插件主界面手动选取游戏。

- **文档**
  - 更新支持的 Ren’Py 版本及 RPG Maker Web runtime 说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->