### PR TITLE
refactor(app)修改双击退出判定时长

### DIFF
--- a/engine/src/main/java/com/core/engine/DoubleBackExit.java
+++ b/engine/src/main/java/com/core/engine/DoubleBackExit.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import java.util.WeakHashMap;
 
 public final class DoubleBackExit {
-    private static final long EXIT_WINDOW_MS = 2_000L;
+    private static final long EXIT_WINDOW_MS = 500L;
     private static final Map<Activity, Long> LAST_BACK_TIME = new WeakHashMap<>();
     private static final Map<Activity, Boolean> SUPPRESS_BACK_UP = new WeakHashMap<>();
 

--- a/engine/src/main/java/com/yuri/onscripter/ONScripter.java
+++ b/engine/src/main/java/com/yuri/onscripter/ONScripter.java
@@ -12,6 +12,7 @@ import android.os.Environment;
 import android.os.ParcelFileDescriptor;
 import android.util.Log;
 import android.view.Gravity;
+import android.view.InputDevice;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
@@ -109,7 +110,10 @@ public class ONScripter extends SDLActivity {
     @Override public boolean dispatchKeyEvent(KeyEvent event) {
         // BACK 首按透传 ESC 给 ONS（游戏内取消/右键语义），2 秒内双击真正退出；
         // ESC 的 down+up 在 DOWN 时成对发送，UP 一律吞掉，避免重复/悬空事件。
+        // 鼠标来源的 BACK（侧键）静默消费：不透传 ESC、不计入双击退出
+        //（与 libsdl3 链 SDLSurface 吞掉鼠标 BACK 的净行为一致）。
         if (event != null && event.getKeyCode() == KeyEvent.KEYCODE_BACK) {
+            if ((event.getSource() & InputDevice.SOURCE_MOUSE) != 0) return true;
             switch (event.getAction()) {
                 case KeyEvent.ACTION_DOWN:
                     if (event.getRepeatCount() == 0) {


### PR DESCRIPTION
## 修改内容

修改双击退出的判定时间至0.5秒，以及修复了 #39 可能在极端情况下产生非预期行为

## 修改原因

此次改动后，误触退出的概率将大大降低。0.5秒的时间足够绝大多数人执行第二次返回操作退出游戏，同时也短于大多数游戏内的返回的动画，不会影响正常的游戏体验


## 测试情况

- [x] 已完成本地测试
- [x] 原有功能正常
- [x] 已在多个设备测试

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能优化**
  * 缩短双击返回退出的触发时间窗口，使退出操作响应更快。
  * 鼠标触发的返回事件将不再误触发退出或发送 ESC，提升操作稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->