### PR TITLE
feat: 游戏目录支持手动输入路径并改用

### DIFF
--- a/app/src/main/java/com/tyranor/next/core/game/scan/EngineScanner.kt
+++ b/app/src/main/java/com/tyranor/next/core/game/scan/EngineScanner.kt
@@ -289,6 +289,16 @@ object EngineScanner {
         return existing
     }
 
+    fun saveRoot(context: Context, rootPath: String): List<String> {
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        val existing = loadRoots(context).toMutableList()
+        val key = rootPath.trim()
+        val added = !existing.contains(key)
+        if (added) existing.add(key)
+        prefs.edit().putString(KEY_ROOTS, existing.joinToString(10.toChar().toString())).apply()
+        if (added) _rootsRevision.value++
+        return existing
+    }
     fun removeRoot(context: Context, uri: Uri) {
         val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
         val current = loadRoots(context)

--- a/app/src/main/java/com/tyranor/next/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/settings/SettingsScreen.kt
@@ -332,14 +332,14 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     Text(
                         "输入游戏目录的绝对路径，例如 /storage/emulated/0/游戏",
-                        style = MiuixTheme.textStyles.bodyMedium,
-                        color = MiuixTheme.colorScheme.onSurfaceVariant,
+                        style = MiuixTheme.textStyles.main,
+                        color = MiuixTheme.colorScheme.onBackground,
                     )
                     AppSearchField(
                         query = pathInput,
                         onQueryChange = { pathInput = it },
                         modifier = Modifier.fillMaxWidth(),
-                        textStyle = MiuixTheme.textStyles.bodyMedium,
+                        textStyle = MiuixTheme.textStyles.main,
                     )
                 }
             },

--- a/app/src/main/java/com/tyranor/next/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/settings/SettingsScreen.kt
@@ -330,11 +330,6 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
             title = { Text("输入文件夹路径", style = MaterialTheme.typography.titleMedium) },
             text = {
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Text(
-                        "输入游戏目录的绝对路径，例如 /storage/emulated/0/游戏",
-                        style = MiuixTheme.textStyles.main,
-                        color = MiuixTheme.colorScheme.onBackground,
-                    )
                     AppSearchField(
                         query = pathInput,
                         onQueryChange = { pathInput = it },

--- a/app/src/main/java/com/tyranor/next/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/settings/SettingsScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -95,6 +96,8 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
     var showGroupDialog by remember { mutableStateOf(false) }
     var showScanDirs by remember { mutableStateOf(false) }
     var scanDirs by remember { mutableStateOf(EngineScanner.loadRoots(ctx)) }
+    var showPathDialog by remember { mutableStateOf(false) }
+    var pathInput by remember { mutableStateOf("") }
     LaunchedEffect(Unit) {
         EngineScanner.rootsRevision.collect {
             scanDirs = withContext(Dispatchers.IO) { EngineScanner.loadRoots(ctx) }
@@ -308,10 +311,51 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
             confirmButton = {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     TextButton(
+                        onClick = { showPathDialog = true },
+                        modifier = Modifier.padding(end = 8.dp),
+                    ) { Text("输入路径") }
+                    TextButton(
                         onClick = { dirPicker.launch(null) },
                         modifier = Modifier.padding(end = 8.dp),
                     ) { Text("添加目录") }
                     TextButton(onClick = { showScanDirs = false }) { Text("完成") }
+                }
+            },
+        )
+    }
+
+    if (showPathDialog) {
+        AppAlertDialog(
+            onDismissRequest = { showPathDialog = false },
+            title = { Text("输入文件夹路径", style = MaterialTheme.typography.titleMedium) },
+            text = {
+                OutlinedTextField(
+                    value = pathInput,
+                    onValueChange = { pathInput = it },
+                    singleLine = true,
+                    label = { Text("/storage/emulated/0/...") },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            },
+            confirmButton = {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    TextButton(
+                        onClick = {
+                            val trimmed = pathInput.trim()
+                            val target = File(trimmed)
+                            val ok = runCatching { target.isDirectory }.getOrDefault(false)
+                            if (ok) {
+                                EngineScanner.saveRoot(ctx, trimmed)
+                                scanDirs = EngineScanner.loadRoots(ctx)
+                                showPathDialog = false
+                                pathInput = ""
+                            } else {
+                                Toast.makeText(ctx, "路径不存在或不是文件夹", Toast.LENGTH_SHORT).show()
+                            }
+                        },
+                        modifier = Modifier.padding(end = 8.dp),
+                    ) { Text("确定") }
+                    TextButton(onClick = { showPathDialog = false }) { Text("取消") }
                 }
             },
         )
@@ -854,13 +898,25 @@ private val ART_PATCH_MAP = listOf(
 )
 
 /** 游戏目录 URI → 可读目录名（取 SAF documentId 的最后一段，失败回退原 uri）。 */
-private fun scanDirName(context: android.content.Context, uri: String): String = runCatching {
-    val docId = DocumentsContract.getTreeDocumentId(android.net.Uri.parse(uri))
-    docId.substringAfterLast(':').substringAfterLast('/').ifBlank { uri }
-}.getOrDefault(uri)
+private fun scanDirName(context: android.content.Context, uri: String): String =
+    if (uri.startsWith('/')) {
+        runCatching { File(uri).name.takeIf { it.isNotBlank() } ?: uri }.getOrDefault(uri)
+    } else {
+        runCatching {
+            val docId = DocumentsContract.getTreeDocumentId(android.net.Uri.parse(uri))
+            docId.substringAfterLast(':').substringAfterLast('/').ifBlank { uri }
+        }.getOrDefault(uri)
+    }
+
 
 /** 游戏根目录是否仍可访问（被改名/删除/权限失效时返回 false；TF 卡暂时拔出也会显示失效，重插后恢复）。 */
-private fun isScanDirValid(context: android.content.Context, uri: String): Boolean = runCatching {
-    val doc = DocumentFile.fromTreeUri(context, android.net.Uri.parse(uri))
-    doc != null && doc.isDirectory
-}.getOrDefault(false)
+private fun isScanDirValid(context: android.content.Context, uri: String): Boolean =
+    if (uri.startsWith('/')) {
+        runCatching { File(uri).isDirectory }.getOrDefault(false)
+    } else {
+        runCatching {
+            val doc = DocumentFile.fromTreeUri(context, android.net.Uri.parse(uri))
+            doc != null && doc.isDirectory
+        }.getOrDefault(false)
+    }
+

--- a/app/src/main/java/com/tyranor/next/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/settings/SettingsScreen.kt
@@ -33,7 +33,7 @@ import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
+import com.tyranor.next.ui.common.AppSearchField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -329,13 +329,19 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
             onDismissRequest = { showPathDialog = false },
             title = { Text("输入文件夹路径", style = MaterialTheme.typography.titleMedium) },
             text = {
-                OutlinedTextField(
-                    value = pathInput,
-                    onValueChange = { pathInput = it },
-                    singleLine = true,
-                    label = { Text("/storage/emulated/0/...") },
-                    modifier = Modifier.fillMaxWidth(),
-                )
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        "输入游戏目录的绝对路径，例如 /storage/emulated/0/游戏",
+                        style = MiuixTheme.textStyles.bodyMedium,
+                        color = MiuixTheme.colorScheme.onSurfaceVariant,
+                    )
+                    AppSearchField(
+                        query = pathInput,
+                        onQueryChange = { pathInput = it },
+                        modifier = Modifier.fillMaxWidth(),
+                        textStyle = MiuixTheme.textStyles.bodyMedium,
+                    )
+                }
             },
             confirmButton = {
                 Row(verticalAlignment = Alignment.CenterVertically) {


### PR DESCRIPTION
 简述
功能增强：游戏目录配置项 #42
在“设置 → 游戏目录添加”弹窗中新增“输入路径”入口，允许用户手动填写游戏目录绝对路径。输入框按项目规范改用 Miuix 组件 `AppSearchField`
修改文件路径为
 app/src/main/java/com/tyranor/next/core/game/scan/EngineScanner.kt
app/src/main/java/com/tyranor/next/ui/settings/SettingsScreen.kt 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 设置页新增手动输入游戏目录路径的功能。
  - 输入有效目录后可保存为扫描目录，并自动刷新目录列表。
  - 同时支持本地文件路径和 SAF URI。
- **问题修复**
  - 优化目录路径保存逻辑，自动清理首尾空格并去除重复路径。
  - 输入无效路径时显示明确的错误提示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->