### PR TITLE
feat(krkr): 新增虚拟鼠标缩放比与菜单按钮不透明度（#48）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 .kotlin/
 
 .trae/
+.zcode/
 
 # ===== IDE =====
 .idea/

--- a/app/src/main/java/com/tyranor/next/core/game/launch/EngineLauncher.kt
+++ b/app/src/main/java/com/tyranor/next/core/game/launch/EngineLauncher.kt
@@ -378,12 +378,15 @@ object EngineLauncher {
             // 注意：buildKrEnginePrefsJson 遍历的是全局键（kr_renderer 等），
             // 而单游戏覆盖以 PerGameSettingsStore.KR_FIELDS（renderer 等）存储，需做键名映射。
             runCatching {
+                check(EngineSettingsStore.KR_RENDER_PREF_KEYS.size == PerGameSettingsStore.KR_FIELDS.size) {
+                    "KR pref keys / fields size mismatch"
+                }
                 val renderKeyMap = EngineSettingsStore.KR_RENDER_PREF_KEYS
                     .zip(PerGameSettingsStore.KR_FIELDS).toMap()
                 putExtra("krkr_engine_prefs", EngineSettingsStore.buildKrEnginePrefsJson(context) { globalKey ->
-                    renderKeyMap[globalKey]?.let { PerGameSettingsStore.getStr(context, gid, it) }
+                    renderKeyMap[globalKey]?.let { PerGameSettingsStore.getStr(context, gid, it)?.trim() }
                 })
-            }
+            }.onFailure { android.util.Log.w("EngineLauncher", "build krkr_engine_prefs failed", it) }
         }
     }
 

--- a/app/src/main/java/com/tyranor/next/core/settings/EngineSettingsStore.kt
+++ b/app/src/main/java/com/tyranor/next/core/settings/EngineSettingsStore.kt
@@ -26,6 +26,8 @@ object EngineSettingsStore {
     const val KEY_KR_OGL_MAX_TEXSIZE = "kr_ogl_max_texsize"
     const val KEY_KR_OGL_ACCURATE_RENDER = "kr_ogl_accurate_render"
     const val KEY_KR_FPS_LIMIT = "kr_fps_limit"
+    const val KEY_KR_VCURSOR_SCALE = "kr_vcursor_scale"
+    const val KEY_KR_MENU_HANDLER_OPA = "kr_menu_handler_opa"
     const val KEY_KR_SCOPED_SAVE_DIR = "kr_scoped_save_dir"
 
     // Artemis 应用级默认
@@ -51,6 +53,22 @@ object EngineSettingsStore {
 
     const val RENDERER_SOFTWARE = "software"
     const val RENDERER_OPENGL = "opengl"
+
+    // 写入引擎 XML（Kirikiroid2Preference.xml/GlobalPreference.xml）的 Item 键名，
+    // 与 libgame.so 内 IndividualConfigManager 读取的键一致，键名不可改。
+    const val ENGINE_VCURSOR_SCALE = "vcursor_scale"
+    const val ENGINE_MENU_HANDLER_OPA = "menu_handler_opa"
+    // 供 krkr_engine_prefs JSON 写入引擎 XML 时的键名映射（prefs 键 → 引擎 Item 键）
+    private val KR_ENGINE_PREF_KEY_MAP = mapOf(
+        KEY_KR_VCURSOR_SCALE to ENGINE_VCURSOR_SCALE,
+        KEY_KR_MENU_HANDLER_OPA to ENGINE_MENU_HANDLER_OPA,
+    )
+    // 虚拟鼠标缩放比（1..100，引擎默认 100；1..150 档在 150% 时已超出屏幕，收敛至 100）
+    val KR_VCURSOR_SCALE_RANGE = 1..100
+    val KR_VCURSOR_SCALES: Set<String> = KR_VCURSOR_SCALE_RANGE.map { it.toString() }.toSet()
+    // 菜单按钮不透明度（1..100，引擎默认 100；滚动条 1..100 全可选）
+    val KR_MENU_HANDLER_OPA_RANGE = 1..100
+    val KR_MENU_HANDLER_OPAS: Set<String> = KR_MENU_HANDLER_OPA_RANGE.map { it.toString() }.toSet()
     const val MEM_USAGE_UNLIMITED = "unlimited"
     const val MEM_USAGE_HIGH = "high"
     const val MEM_USAGE_MEDIUM = "medium"
@@ -73,6 +91,7 @@ object EngineSettingsStore {
         KEY_KR_RENDERER, KEY_KR_SOFTWARE_DRAW_THREAD, KEY_KR_SOFTWARE_COMPRESS_TEX,
         KEY_KR_OGL_COMPRESS_TEX, KEY_KR_MEM_USAGE, KEY_KR_OGL_MAX_TEXSIZE,
         KEY_KR_OGL_ACCURATE_RENDER, KEY_KR_FPS_LIMIT,
+        KEY_KR_VCURSOR_SCALE, KEY_KR_MENU_HANDLER_OPA,
     )
 
     private fun prefs(context: Context) =
@@ -123,14 +142,41 @@ object EngineSettingsStore {
     fun setKrOglAccurateRender(c: Context, v: String) = setKrPref(c, KEY_KR_OGL_ACCURATE_RENDER, v)
     fun getKrFpsLimit(c: Context): String { val v = krPref(c, KEY_KR_FPS_LIMIT); return if (v in setOf("60", "45", "30", "15")) v else "" }
     fun setKrFpsLimit(c: Context, v: String) = setKrPref(c, KEY_KR_FPS_LIMIT, v)
+    fun getKrVCursorScale(c: Context): String { val v = krPref(c, KEY_KR_VCURSOR_SCALE).trim(); return if (v in KR_VCURSOR_SCALES) v else "" }
+    fun setKrVCursorScale(c: Context, v: String) { val t = v.trim(); if (t.isEmpty() || t in KR_VCURSOR_SCALES) setKrPref(c, KEY_KR_VCURSOR_SCALE, t) }
+    fun getKrMenuHandlerOpa(c: Context): String { val v = krPref(c, KEY_KR_MENU_HANDLER_OPA).trim(); return if (v in KR_MENU_HANDLER_OPAS) v else "" }
+    fun setKrMenuHandlerOpa(c: Context, v: String) { val t = v.trim(); if (t.isEmpty() || t in KR_MENU_HANDLER_OPAS) setKrPref(c, KEY_KR_MENU_HANDLER_OPA, t) }
 
     /** 组装 krkr_engine_prefs JSON：{<引擎键>:{v, s}}。overrideGetter 返回某键的单游戏覆盖（null=跟随全局）。 */
     fun buildKrEnginePrefsJson(c: Context, overrideGetter: (String) -> String? = { null }): String {
         val json = JSONObject()
         KR_RENDER_PREF_KEYS.forEach { key ->
-            val override = overrideGetter(key)
-            val value = override ?: prefs(c).getString(key, null).orEmpty()
-            json.put(key, JSONObject().put("v", value).put("s", if (override != null) "game" else "global"))
+            val rawOverride = overrideGetter(key)
+            val override = rawOverride?.trim()?.takeIf { it.isNotEmpty() || rawOverride == "" }
+            // 仅保留合法值或显式空串（引擎默认），非法值按跟随全局处理
+            val sanitizedOverride = when (key) {
+                KEY_KR_VCURSOR_SCALE -> override?.let { if (it.isEmpty() || it in KR_VCURSOR_SCALES) it else null }
+                KEY_KR_MENU_HANDLER_OPA -> override?.let { if (it.isEmpty() || it in KR_MENU_HANDLER_OPAS) it else null }
+                else -> override
+            }
+            val globalRaw = prefs(c).getString(key, null).orEmpty().trim()
+            val sanitizedGlobal = when (key) {
+                KEY_KR_VCURSOR_SCALE -> if (globalRaw in KR_VCURSOR_SCALES) globalRaw else ""
+                KEY_KR_MENU_HANDLER_OPA -> if (globalRaw in KR_MENU_HANDLER_OPAS) globalRaw else ""
+                else -> prefs(c).getString(key, null).orEmpty()
+            }
+            val rawValue = sanitizedOverride ?: sanitizedGlobal
+            // 虚拟鼠标：prefs 存 1..100（百分比），引擎需 0.01..1.00 浮点字符串
+            val value = when (key) {
+                KEY_KR_VCURSOR_SCALE -> if (rawValue.isEmpty()) "" else {
+                    val p = rawValue.toIntOrNull()
+                    if (p == null || p !in KR_VCURSOR_SCALE_RANGE) rawValue
+                    else String.format(java.util.Locale.US, "%.2f", p / 100.0).trimEnd('0').trimEnd('.')
+                }
+                else -> rawValue
+            }
+            val engineKey = KR_ENGINE_PREF_KEY_MAP[key] ?: key
+            json.put(engineKey, JSONObject().put("v", value).put("s", if (sanitizedOverride != null) "game" else "global"))
         }
         return json.toString()
     }

--- a/app/src/main/java/com/tyranor/next/core/settings/PerGameSettingsStore.kt
+++ b/app/src/main/java/com/tyranor/next/core/settings/PerGameSettingsStore.kt
@@ -29,9 +29,12 @@ object PerGameSettingsStore {
     const val F_OGL_MAX_TEXSIZE = "ogl_max_texsize"
     const val F_OGL_ACCURATE_RENDER = "ogl_accurate_render"
     const val F_FPS_LIMIT = "fps_limit"
+    const val F_VCURSOR_SCALE = "vcursor_scale"
+    const val F_MENU_HANDLER_OPA = "menu_handler_opa"
     val KR_FIELDS = listOf(
         F_RENDERER, F_SOFTWARE_DRAW_THREAD, F_SOFTWARE_COMPRESS_TEX, F_OGL_COMPRESS_TEX,
         F_MEM_USAGE, F_OGL_MAX_TEXSIZE, F_OGL_ACCURATE_RENDER, F_FPS_LIMIT,
+        F_VCURSOR_SCALE, F_MENU_HANDLER_OPA,
     )
 
     // Artemis
@@ -81,7 +84,7 @@ object PerGameSettingsStore {
     fun setStr(context: Context, gameId: String, key: String, value: String?) {
         if (gameId.isBlank()) return
         val j = load(context, gameId)
-        if (value == null) j.remove(key) else j.put(key, value)
+        if (value == null) j.remove(key) else j.put(key, value.trim())
         persist(context, gameId, j)
     }
 

--- a/app/src/main/java/com/tyranor/next/ui/settings/PerGameSettingsScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/settings/PerGameSettingsScreen.kt
@@ -64,7 +64,7 @@ fun PerGameSettingsScreen(game: ScanGame) {
     var krFont by remember { mutableStateOf(PerGameSettingsStore.getStr(ctx, gid, PerGameSettingsStore.F_DEFAULT_FONT)) }
     var krForceFont by remember { mutableStateOf(PerGameSettingsStore.getBool(ctx, gid, PerGameSettingsStore.F_FORCE_DEFAULT_FONT)) }
     val krRender = PerGameSettingsStore.KR_FIELDS.associateWith { field ->
-        remember(field) { mutableStateOf(PerGameSettingsStore.getStr(ctx, gid, field)) }
+        remember(gid, field) { mutableStateOf(PerGameSettingsStore.getStr(ctx, gid, field)) }
     }
 
     var artVersion by remember { mutableStateOf(PerGameSettingsStore.getStr(ctx, gid, PerGameSettingsStore.F_ART_VERSION)) }
@@ -142,6 +142,8 @@ fun PerGameSettingsScreen(game: ScanGame) {
     val globalOglCompress = EngineSettingsStore.getKrOglCompressTex(ctx)
     val globalTexsize = EngineSettingsStore.getKrOglMaxTexsize(ctx)
     val globalFps = EngineSettingsStore.getKrFpsLimit(ctx)
+    val globalVCursorScale = EngineSettingsStore.getKrVCursorScale(ctx)
+    val globalMenuOpa = EngineSettingsStore.getKrMenuHandlerOpa(ctx)
     val effRenderer = krRender[PerGameSettingsStore.F_RENDERER]!!.value ?: globalRenderer
 
     fun save() {
@@ -245,6 +247,27 @@ fun PerGameSettingsScreen(game: ScanGame) {
                                             krRender[PerGameSettingsStore.F_OGL_MAX_TEXSIZE]!!.value = it
                                         }
                                     }
+                                }
+                            }
+                        }
+                        if (!isSdl3) {
+                            item {
+                                SectionCard("操作") {
+                                    // 仅 kirikiri2 内核生效（与全局设置一致）
+                                    OverrideChoice(
+                                        "虚拟鼠标缩放比",
+                                        KR_VCURSOR_SCALE_MAP2,
+                                        globalVCursorScale,
+                                        krRender[PerGameSettingsStore.F_VCURSOR_SCALE]!!.value,
+                                        emptyLabel = "引擎默认",
+                                    ) { krRender[PerGameSettingsStore.F_VCURSOR_SCALE]!!.value = it }
+                                    OverrideChoice(
+                                        "菜单按钮不透明度",
+                                        KR_MENU_OPA_MAP2,
+                                        globalMenuOpa,
+                                        krRender[PerGameSettingsStore.F_MENU_HANDLER_OPA]!!.value,
+                                        emptyLabel = "引擎默认",
+                                    ) { krRender[PerGameSettingsStore.F_MENU_HANDLER_OPA]!!.value = it }
                                 }
                             }
                         }
@@ -419,3 +442,5 @@ private fun onsStr(o: JSONObject, key: String, def: String): String? = if (o.has
 private fun putIfNotNull(o: JSONObject, key: String, v: Boolean?) { if (v != null) o.put(key, v) else o.remove(key) }
 private fun putIfNotNull(o: JSONObject, key: String, v: String?) { if (v != null) o.put(key, v) else o.remove(key) }
 private fun String.decode(): String = if (this == "sjis") "sjis" else if (this == "utf8") "utf8" else "gbk"
+private val KR_VCURSOR_SCALE_MAP2 = mapOf("" to "引擎默认") + (1..100).associate { it.toString() to "$it%" }
+private val KR_MENU_OPA_MAP2 = mapOf("" to "引擎默认") + (1..100).associate { it.toString() to "$it%" }

--- a/app/src/main/java/com/tyranor/next/ui/settings/PerGameSettingsScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/settings/PerGameSettingsScreen.kt
@@ -252,21 +252,21 @@ fun PerGameSettingsScreen(game: ScanGame) {
                         }
                         if (!isSdl3) {
                             item {
-                                SectionCard("操作") {
+                                SectionCard(stringResource(R.string.engine_settings_operation)) {
                                     // 仅 kirikiri2 内核生效（与全局设置一致）
                                     OverrideChoice(
-                                        "虚拟鼠标缩放比",
-                                        KR_VCURSOR_SCALE_MAP2,
+                                        stringResource(R.string.engine_settings_vcursor_scale),
+                                        krkrPercentOptions().toMap(),
                                         globalVCursorScale,
                                         krRender[PerGameSettingsStore.F_VCURSOR_SCALE]!!.value,
-                                        emptyLabel = "引擎默认",
+                                        emptyLabel = stringResource(R.string.engine_option_engine_default),
                                     ) { krRender[PerGameSettingsStore.F_VCURSOR_SCALE]!!.value = it }
                                     OverrideChoice(
-                                        "菜单按钮不透明度",
-                                        KR_MENU_OPA_MAP2,
+                                        stringResource(R.string.engine_settings_menu_handler_opa),
+                                        krkrPercentOptions().toMap(),
                                         globalMenuOpa,
                                         krRender[PerGameSettingsStore.F_MENU_HANDLER_OPA]!!.value,
-                                        emptyLabel = "引擎默认",
+                                        emptyLabel = stringResource(R.string.engine_option_engine_default),
                                     ) { krRender[PerGameSettingsStore.F_MENU_HANDLER_OPA]!!.value = it }
                                 }
                             }
@@ -442,5 +442,3 @@ private fun onsStr(o: JSONObject, key: String, def: String): String? = if (o.has
 private fun putIfNotNull(o: JSONObject, key: String, v: Boolean?) { if (v != null) o.put(key, v) else o.remove(key) }
 private fun putIfNotNull(o: JSONObject, key: String, v: String?) { if (v != null) o.put(key, v) else o.remove(key) }
 private fun String.decode(): String = if (this == "sjis") "sjis" else if (this == "utf8") "utf8" else "gbk"
-private val KR_VCURSOR_SCALE_MAP2 = mapOf("" to "引擎默认") + (1..100).associate { it.toString() to "$it%" }
-private val KR_MENU_OPA_MAP2 = mapOf("" to "引擎默认") + (1..100).associate { it.toString() to "$it%" }

--- a/app/src/main/java/com/tyranor/next/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/settings/SettingsScreen.kt
@@ -638,11 +638,11 @@ private fun LazyListPlaceholder(
         }
 
         if (kind == EngineSettingsKind.KRKR && !isSdl3) item {
-            EngineCard("操作") {
+            EngineCard(stringResource(R.string.engine_settings_operation)) {
                 // 仅 kirikiri2 内核（libgame.so）读取这两项偏好，krkrsdl3 走命令行参数不生效
                 // 虚拟鼠标 1..100%，空心横条（1..150 档已验证超出屏幕，已收敛）
-                ContinuousSliderRow("虚拟鼠标缩放比", KR_VCURSOR_SCALE_MAP, krVCursorScale, onKrVCursorScale)
-                ContinuousSliderRow("菜单按钮不透明度", KR_MENU_OPA_MAP, krMenuOpa, onKrMenuOpa)
+                ContinuousSliderRow(stringResource(R.string.engine_settings_vcursor_scale), krkrPercentOptions(), krVCursorScale, onKrVCursorScale)
+                ContinuousSliderRow(stringResource(R.string.engine_settings_menu_handler_opa), krkrPercentOptions(), krMenuOpa, onKrMenuOpa)
             }
         }
 
@@ -861,8 +861,10 @@ private fun importFont(ctx: android.content.Context, uri: Uri): String? = try {
     null
 }
 
-private val KR_VCURSOR_SCALE_MAP = listOf("" to "引擎默认") + (1..100).map { it.toString() to "$it%" }
-private val KR_MENU_OPA_MAP = listOf("" to "引擎默认") + (1..100).map { it.toString() to "$it%" }
+/** KRKR 百分比选项：""（引擎默认）+ 1..100%，供全局滑杆与单游戏下拉共用；顶层 val 取不到 stringResource，故封装为函数。 */
+@Composable
+internal fun krkrPercentOptions(): List<Pair<String, String>> =
+    listOf("" to stringResource(R.string.engine_option_engine_default)) + (1..100).map { it.toString() to "$it%" }
 /** 游戏目录 URI → 可读目录名（取 SAF documentId 的最后一段，失败回退原 uri）。 */
 private fun scanDirName(context: android.content.Context, uri: String): String = runCatching {
     val docId = DocumentsContract.getTreeDocumentId(android.net.Uri.parse(uri))

--- a/app/src/main/java/com/tyranor/next/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/settings/SettingsScreen.kt
@@ -398,6 +398,8 @@ internal fun EngineSettingsDetailScreen(kind: EngineSettingsKind) {
     var krTexsize by remember { mutableStateOf(EngineSettingsStore.getKrOglMaxTexsize(ctx)) }
     var krAccurate by remember { mutableStateOf(EngineSettingsStore.getKrOglAccurateRender(ctx)) }
     var krFps by remember { mutableStateOf(EngineSettingsStore.getKrFpsLimit(ctx)) }
+    var krVCursorScale by remember { mutableStateOf(EngineSettingsStore.getKrVCursorScale(ctx)) }
+    var krMenuOpa by remember { mutableStateOf(EngineSettingsStore.getKrMenuHandlerOpa(ctx)) }
 
     var ons by remember { mutableStateOf(EngineSettingsStore.loadOns(ctx)) }
 
@@ -437,6 +439,8 @@ internal fun EngineSettingsDetailScreen(kind: EngineSettingsKind) {
         EngineSettingsStore.setKrOglMaxTexsize(ctx, krTexsize)
         EngineSettingsStore.setKrOglAccurateRender(ctx, krAccurate)
         EngineSettingsStore.setKrFpsLimit(ctx, krFps)
+        EngineSettingsStore.setKrVCursorScale(ctx, krVCursorScale)
+        EngineSettingsStore.setKrMenuHandlerOpa(ctx, krMenuOpa)
         EngineSettingsStore.saveOns(ctx, ons)
         EngineSettingsStore.setArtEngineVersion(ctx, artVersion)
         EngineSettingsStore.setArtRotateScreen(ctx, artRotate)
@@ -481,6 +485,7 @@ internal fun EngineSettingsDetailScreen(kind: EngineSettingsKind) {
                 kind,
                 krVersion, krKernel, krScoped, krFont, krForceFont, krRenderer, krDrawThread,
                 krSwCompress, krOglCompress, krMem, krTexsize, krAccurate, krFps, isSdl3, krIs134126,
+                krVCursorScale, krMenuOpa,
                 ons, artVersion, artRotate, artPatch, tyExternal, tyScoped, rpgMakerMod, renpyVersion, fontLauncher,
                 topInset = innerPadding.calculateTopPadding(),
                 onKrVersion = { krVersion = it },
@@ -495,6 +500,8 @@ internal fun EngineSettingsDetailScreen(kind: EngineSettingsKind) {
                 onKrTexsize = { krTexsize = it },
                 onKrAccurate = { krAccurate = it },
                 onKrFps = { krFps = it },
+                onKrVCursorScale = { krVCursorScale = it },
+                onKrMenuOpa = { krMenuOpa = it },
                 onResetKrFont = { krFont = "" },
                 onOns = { ons = it },
                 onArtVersion = { artVersion = it },
@@ -549,6 +556,7 @@ private fun LazyListPlaceholder(
     krVersion: String, krKernel: String, krScoped: Boolean, krFont: String, krForceFont: Boolean,
     krRenderer: String, krDrawThread: String, krSwCompress: String, krOglCompress: String,
     krMem: String, krTexsize: String, krAccurate: String, krFps: String, isSdl3: Boolean, krIs134126: Boolean,
+    krVCursorScale: String, krMenuOpa: String,
     ons: EngineSettingsStore.Ons, artVersion: String, artRotate: Boolean, artPatch: String,
     tyExternal: Boolean, tyScoped: Boolean, rpgMakerMod: Boolean, renpyVersion: String, fontLauncher: FontPickerLauncher,
     topInset: Dp,
@@ -556,6 +564,7 @@ private fun LazyListPlaceholder(
     onKrForceFont: (Boolean) -> Unit, onKrRenderer: (String) -> Unit, onKrDrawThread: (String) -> Unit,
     onKrSwCompress: (String) -> Unit, onKrOglCompress: (String) -> Unit, onKrMem: (String) -> Unit,
     onKrTexsize: (String) -> Unit, onKrAccurate: (String) -> Unit, onKrFps: (String) -> Unit,
+    onKrVCursorScale: (String) -> Unit, onKrMenuOpa: (String) -> Unit,
     onResetKrFont: () -> Unit, onOns: (EngineSettingsStore.Ons) -> Unit,
     onArtVersion: (String) -> Unit, onArtRotate: (Boolean) -> Unit, onArtPatch: (String) -> Unit,
     onTyExternal: (Boolean) -> Unit, onTyScoped: (Boolean) -> Unit, onRpgMakerMod: (Boolean) -> Unit,
@@ -625,6 +634,15 @@ private fun LazyListPlaceholder(
                 if (krVersion != EngineSettingsStore.KR_126) {
                     SwitchPreference(title = stringResource(R.string.engine_settings_force_default_font), checked = krForceFont, onCheckedChange = onKrForceFont)
                 }
+            }
+        }
+
+        if (kind == EngineSettingsKind.KRKR && !isSdl3) item {
+            EngineCard("操作") {
+                // 仅 kirikiri2 内核（libgame.so）读取这两项偏好，krkrsdl3 走命令行参数不生效
+                // 虚拟鼠标 1..100%，空心横条（1..150 档已验证超出屏幕，已收敛）
+                ContinuousSliderRow("虚拟鼠标缩放比", KR_VCURSOR_SCALE_MAP, krVCursorScale, onKrVCursorScale)
+                ContinuousSliderRow("菜单按钮不透明度", KR_MENU_OPA_MAP, krMenuOpa, onKrMenuOpa)
             }
         }
 
@@ -758,6 +776,36 @@ private fun EnumSliderRow(
     )
 }
 
+@Composable
+private fun ContinuousSliderRow(
+    label: String,
+    options: List<Pair<String, String>>,
+    current: String,
+    onSelect: (String) -> Unit,
+) {
+    val initIndex = options.indexOfFirst { it.first == current }.takeIf { it >= 0 } ?: 0
+    var sliderIndex by remember(current) { mutableIntStateOf(initIndex) }
+    ArrowPreference(
+        title = label,
+        endActions = {
+            Text(
+                options[sliderIndex].second,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        },
+        onClick = { },
+        bottomAction = {
+            Slider(
+                value = sliderIndex.toFloat(),
+                onValueChange = { sliderIndex = it.roundToInt().coerceIn(0, options.size - 1) },
+                onValueChangeFinished = { onSelect(options[sliderIndex].first) },
+                valueRange = 0f..(options.size - 1).toFloat(),
+            )
+        },
+    )
+}
+
 /** 字体行：Miuix ArrowPreference，右侧展示当前字体；点击弹出「内置字体 / 选择字体文件」。 */
 @Composable
 private fun FontRow(label: String, value: String, onReset: () -> Unit, onPick: () -> Unit) {
@@ -813,6 +861,8 @@ private fun importFont(ctx: android.content.Context, uri: Uri): String? = try {
     null
 }
 
+private val KR_VCURSOR_SCALE_MAP = listOf("" to "引擎默认") + (1..100).map { it.toString() to "$it%" }
+private val KR_MENU_OPA_MAP = listOf("" to "引擎默认") + (1..100).map { it.toString() to "$it%" }
 /** 游戏目录 URI → 可读目录名（取 SAF documentId 的最后一段，失败回退原 uri）。 */
 private fun scanDirName(context: android.content.Context, uri: String): String = runCatching {
     val docId = DocumentsContract.getTreeDocumentId(android.net.Uri.parse(uri))

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -161,6 +161,9 @@
     <string name="engine_settings_fps_limit">FPS limit</string>
     <string name="engine_settings_opengl_texture_compression">OpenGL texture compression</string>
     <string name="engine_settings_max_texture_size">Max texture size</string>
+    <string name="engine_settings_operation">Controls</string>
+    <string name="engine_settings_vcursor_scale">Virtual cursor scale</string>
+    <string name="engine_settings_menu_handler_opa">Menu handler opacity</string>
     <string name="engine_settings_font">Font</string>
     <string name="engine_settings_default_font">Default font</string>
     <string name="engine_settings_builtin_font">Built-in font</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -161,6 +161,9 @@
     <string name="engine_settings_fps_limit">FPS 制限</string>
     <string name="engine_settings_opengl_texture_compression">OpenGL テクスチャ圧縮</string>
     <string name="engine_settings_max_texture_size">最大テクスチャサイズ</string>
+    <string name="engine_settings_operation">操作</string>
+    <string name="engine_settings_vcursor_scale">仮想マウスの拡大縮小</string>
+    <string name="engine_settings_menu_handler_opa">メニューハンドラの不透明度</string>
     <string name="engine_settings_font">フォント</string>
     <string name="engine_settings_default_font">既定フォント</string>
     <string name="engine_settings_builtin_font">内蔵フォント</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -161,6 +161,9 @@
     <string name="engine_settings_fps_limit">FPS 限制</string>
     <string name="engine_settings_opengl_texture_compression">OpenGL 纹理压缩</string>
     <string name="engine_settings_max_texture_size">最大纹理尺寸</string>
+    <string name="engine_settings_operation">操作</string>
+    <string name="engine_settings_vcursor_scale">虚拟鼠标缩放比</string>
+    <string name="engine_settings_menu_handler_opa">菜单按钮不透明度</string>
     <string name="engine_settings_font">字体</string>
     <string name="engine_settings_default_font">默认字体</string>
     <string name="engine_settings_builtin_font">内置字体</string>


### PR DESCRIPTION
### 背景
Closes #48：为 KRKR（kirikiri2）补充缺失的 `虚拟鼠标缩放比` 与 `菜单按钮不透明度` 设置。

### 改动
- **Store**：`EngineSettingsStore` 新增 `kr_vcursor_scale`/`kr_menu_handler_opa`（`1..100`，空=引擎默认），`KR_RENDER_PREF_KEYS` 扩展至 10，`buildKrEnginePrefsJson` 增加白名单消毒并将 `kr_vcursor_scale` 的 `1..100%` 转 `0.01..1.00` 浮点写入 `vcursor_scale`，其余直写；`PerGameSettingsStore` 新增 `F_VCURSOR_SCALE`/`F_MENU_HANDLER_OPA` 并加入 `KR_FIELDS`，`setStr` 增加 `trim()`
- **全局 UI**：`SettingsScreen` KRKR `操作` 卡（仅 `!isSdl3`）新增两项空心横条 `ContinuousSliderRow`，`1..100%`
- **单游戏 UI**：`PerGameSettingsScreen` 同步新增 `操作` 卡 `OverrideChoice`（`跟随全局`/`1..100%`）
- **启动链路**：`EngineLauncher` 对 `KR_RENDER_PREF_KEYS`/`KR_FIELDS` 增加长度 `check` 与 `Log.w` 兜底，`trim()` 覆盖读取
- **修复**：`remember(gid,field)` 防跨游戏串台；`.gitignore` 增加 `.zcode/`

### 验证
- `testDebugUnitTest` + `assembleDebug` 通过，`diff --check` 0
- 真机 `AFKUBB5B10000288` `text3` 包安装验证：`GlobalPreference.xml` `vcursor_scale` 如 `69%→"0.69"`、`menu_handler_opa` `100` 落盘正常，`1..150%` 已验证超出屏幕故收敛至 `100%`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - KRKR 引擎新增虚拟鼠标缩放比例和菜单按钮不透明度设置，支持引擎默认值及 1%–100% 范围。
  - 支持为单个游戏单独设置上述选项，并通过滑杆进行调整。
  - 切换游戏时可正确保留各自的渲染设置。

- **改进**
  - 设置保存与应用过程会自动清理无效值及多余空白，提升配置稳定性。
  - 引擎配置异常时记录警告，避免影响其他设置。
  - 新增相关英文、日文和中文界面文本。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->