### PR TITLE
fix(shortcut): 统一 Artemis 补丁确认弹窗并修复审查问题

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,6 +42,7 @@
         <activity
             android:name=".ui.save.SaveManagementActivity"
             android:exported="false" />
+        <!-- 桌面快捷方式回跳蹦床：exported=true 为桌面 Launcher 跨进程显式启动所必需，勿改回 false（见 GameShortcutActivity KDoc） -->
         <activity
             android:name=".ui.game.GameShortcutActivity"
             android:excludeFromRecents="true"

--- a/app/src/main/java/com/tyranor/next/ui/game/ArtemisPatchChoiceDialog.kt
+++ b/app/src/main/java/com/tyranor/next/ui/game/ArtemisPatchChoiceDialog.kt
@@ -1,0 +1,100 @@
+package com.tyranor.next.ui.game
+
+import android.app.AlertDialog
+import android.content.Context
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.tyranor.next.R
+import com.tyranor.next.core.game.launch.EngineLauncher
+import com.tyranor.next.core.game.model.ScanGame
+import com.tyranor.next.ui.common.AppAlertDialog
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+/**
+ * Artemis 补丁确认三选弹窗的统一入口：GameActionsSheet（Compose）与
+ * 桌面快捷方式蹦床 GameShortcutActivity（原生 Activity）共用同一份
+ * 「按钮 → 策略」映射，避免两处语义漂移。
+ *
+ * 语义：总是 → [EngineLauncher.ArtemisPatchChoice.ALWAYS]（持久化 auto）、
+ * 不再 → [EngineLauncher.ArtemisPatchChoice.NEVER]（持久化 off）、
+ * 本次 → [EngineLauncher.ArtemisPatchChoice.ONCE]（不落盘）、取消 → null（不启动）。
+ */
+private enum class PatchChoiceOption(val labelRes: Int) {
+    ALWAYS(R.string.game_patch_always),
+    NEVER(R.string.game_patch_never),
+    ONCE(R.string.game_patch_once),
+}
+
+private fun PatchChoiceOption.toArtemisChoice(): EngineLauncher.ArtemisPatchChoice = when (this) {
+    PatchChoiceOption.ALWAYS -> EngineLauncher.ArtemisPatchChoice.ALWAYS
+    PatchChoiceOption.NEVER -> EngineLauncher.ArtemisPatchChoice.NEVER
+    PatchChoiceOption.ONCE -> EngineLauncher.ArtemisPatchChoice.ONCE
+}
+
+/** Compose 版本：供 GameActionsSheet 在抽屉内弹出（遵循 AppAlertDialog 弹窗规范）。 */
+@Composable
+internal fun ArtemisPatchChoiceDialog(
+    game: ScanGame,
+    onChoice: (EngineLauncher.ArtemisPatchChoice?) -> Unit,
+) {
+    AppAlertDialog(
+        onDismissRequest = { onChoice(null) },
+        title = {
+            Text(stringResource(R.string.game_auto_patch_title), style = MaterialTheme.typography.titleMedium)
+        },
+        text = {
+            Text(
+                stringResource(R.string.game_auto_patch_message, game.title),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = { onChoice(PatchChoiceOption.ALWAYS.toArtemisChoice()) }) {
+                Text(stringResource(PatchChoiceOption.ALWAYS.labelRes))
+            }
+        },
+        dismissButton = {
+            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                TextButton(onClick = { onChoice(PatchChoiceOption.NEVER.toArtemisChoice()) }) {
+                    Text(stringResource(PatchChoiceOption.NEVER.labelRes))
+                }
+                TextButton(onClick = { onChoice(PatchChoiceOption.ONCE.toArtemisChoice()) }) {
+                    Text(stringResource(PatchChoiceOption.ONCE.labelRes))
+                }
+            }
+        },
+    )
+}
+
+/** 原生版本：供非 Compose 的透明蹦床（快捷方式启动）使用，行为与 Compose 版本一致。 */
+suspend fun Context.confirmArtemisPatchChoice(game: ScanGame): EngineLauncher.ArtemisPatchChoice? =
+    suspendCancellableCoroutine { continuation ->
+        val dialog = AlertDialog.Builder(this)
+            .setTitle(R.string.game_auto_patch_title)
+            .setMessage(getString(R.string.game_auto_patch_message, game.title))
+            .setPositiveButton(PatchChoiceOption.ALWAYS.labelRes) { _, _ ->
+                if (continuation.isActive) continuation.resume(PatchChoiceOption.ALWAYS.toArtemisChoice())
+            }
+            .setNegativeButton(PatchChoiceOption.NEVER.labelRes) { _, _ ->
+                if (continuation.isActive) continuation.resume(PatchChoiceOption.NEVER.toArtemisChoice())
+            }
+            .setNeutralButton(PatchChoiceOption.ONCE.labelRes) { _, _ ->
+                if (continuation.isActive) continuation.resume(PatchChoiceOption.ONCE.toArtemisChoice())
+            }
+            .setOnCancelListener {
+                if (continuation.isActive) continuation.resume(null)
+            }
+            .create()
+
+        continuation.invokeOnCancellation { dialog.dismiss() }
+        if (continuation.isActive) {
+            dialog.show()
+            if (!continuation.isActive && dialog.isShowing) dialog.dismiss()
+        }
+    }

--- a/app/src/main/java/com/tyranor/next/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/game/GameScreen.kt
@@ -538,7 +538,11 @@ internal fun GameActionsSheet(
 
     /** Requests a new shortcut or updates the existing shortcut for this game. */
     fun requestDesktopShortcut(customIconUri: android.net.Uri? = null) {
-        if (shortcutRequestInFlight) return
+        if (shortcutRequestInFlight) {
+            // 上一次请求（系统确认框）尚未结束：丢弃新生成的临时图标，避免孤儿文件
+            deleteShortcutCropBitmap(context.applicationContext, customIconUri)
+            return
+        }
         shortcutRequestInFlight = true
         scope.launch {
             val result = try {
@@ -609,7 +613,12 @@ internal fun GameActionsSheet(
     }
 
     ModalBottomSheet(
-        onDismissRequest = onDismiss,
+        onDismissRequest = {
+            // 关闭抽屉时一并清除裁切弹窗状态，避免 rememberSaveable 在下一次打开时残留旧弹窗
+            shortcutCropUriText = null
+            shortcutPickerForNoCover = false
+            onDismiss()
+        },
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
         containerColor = MaterialTheme.colorScheme.background,
         contentWindowInsets = { WindowInsets(0.dp) },
@@ -737,38 +746,11 @@ internal fun GameActionsSheet(
 
     // ===== Artemis 自动补丁确认：总是（记住 auto）/ 本次 / 不再（记住 off）；点遮罩取消 = 不启动 =====
     if (showPatchConfirm) {
-        AppAlertDialog(
-            onDismissRequest = { showPatchConfirm = false },
-            title = { Text(stringResource(R.string.game_auto_patch_title), style = MaterialTheme.typography.titleMedium) },
-            text = {
-                Text(
-                    stringResource(R.string.game_auto_patch_message, game.title),
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        showPatchConfirm = false
-                        startLaunch(EngineLauncher.ArtemisPatchChoice.ALWAYS)
-                    },
-                ) { Text(stringResource(R.string.game_patch_always)) }
-            },
-            dismissButton = {
-                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                    TextButton(
-                        onClick = {
-                            showPatchConfirm = false
-                            startLaunch(EngineLauncher.ArtemisPatchChoice.NEVER)
-                        },
-                    ) { Text(stringResource(R.string.game_patch_never)) }
-                    TextButton(
-                        onClick = {
-                            showPatchConfirm = false
-                            startLaunch(EngineLauncher.ArtemisPatchChoice.ONCE)
-                        },
-                    ) { Text(stringResource(R.string.game_patch_once)) }
-                }
+        ArtemisPatchChoiceDialog(
+            game = game,
+            onChoice = { choice ->
+                showPatchConfirm = false
+                if (choice != null) startLaunch(choice)
             },
         )
     }

--- a/app/src/main/java/com/tyranor/next/ui/game/GameShortcutActivity.kt
+++ b/app/src/main/java/com/tyranor/next/ui/game/GameShortcutActivity.kt
@@ -1,6 +1,5 @@
 package com.tyranor.next.ui.game
 
-import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -15,20 +14,20 @@ import com.tyranor.next.core.game.shortcut.GameShortcutManager
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
-import kotlin.coroutines.resume
 
-/** Transparent trampoline that resolves a pinned shortcut against the current game library. */
+/**
+ * 桌面快捷方式回跳蹦床。
+ *
+ * 该 Activity 是 `ShortcutInfo.setIntent` 的目标，由桌面 Launcher 以显式 Intent 跨进程启动，
+ * 因此 `exported=true` 是**必需**的（改为 false 会触发 Permission Denial），请勿回退。
+ * 入参 `EXTRA_SHORTCUT_ID` 为库内游戏 uri 的 SHA-256，可通过 [GameShortcutActivity.createIntent]
+ * 重新解析库内游戏并启动，必要时先做 Artemis 补丁确认。
+ */
 class GameShortcutActivity : ComponentActivity() {
-    /** Resolves the shortcut ID, confirms Artemis patch policy, and launches the game. */
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (savedInstanceState != null) {
-            finish()
-            return
-        }
-
+        // 配置变更/进程重建后继续（弹窗会重新出现），不要静默 finish，否则用户点快捷方式无反馈
         val shortcutId = intent.getStringExtra(EXTRA_SHORTCUT_ID)
         if (shortcutId.isNullOrBlank()) {
             showUnavailableAndFinish()
@@ -50,7 +49,7 @@ class GameShortcutActivity : ComponentActivity() {
                     EngineLauncher.needsArtemisPatchConfirm(applicationContext, game)
                 }
                 val patchChoice = if (needsArtemisPatchConfirm) {
-                    awaitArtemisPatchChoice(game) ?: return@launch
+                    confirmArtemisPatchChoice(game) ?: return@launch
                 } else {
                     null
                 }
@@ -84,34 +83,6 @@ class GameShortcutActivity : ComponentActivity() {
     private fun showLaunchFailure(error: Throwable) {
         Log.e(TAG, "Shortcut game launch failed", error)
         Toast.makeText(this, R.string.launch_failed, Toast.LENGTH_LONG).show()
-    }
-
-    /** Suspends until the user chooses an Artemis patch policy or dismisses the dialog. */
-    private suspend fun awaitArtemisPatchChoice(
-        game: com.tyranor.next.core.game.model.ScanGame,
-    ): EngineLauncher.ArtemisPatchChoice? = suspendCancellableCoroutine { continuation ->
-        val dialog = AlertDialog.Builder(this)
-            .setTitle(R.string.game_auto_patch_title)
-            .setMessage(getString(R.string.game_auto_patch_message, game.title))
-            .setPositiveButton(R.string.game_patch_always) { _, _ ->
-                if (continuation.isActive) continuation.resume(EngineLauncher.ArtemisPatchChoice.ALWAYS)
-            }
-            .setNegativeButton(R.string.game_patch_never) { _, _ ->
-                if (continuation.isActive) continuation.resume(EngineLauncher.ArtemisPatchChoice.NEVER)
-            }
-            .setNeutralButton(R.string.game_patch_once) { _, _ ->
-                if (continuation.isActive) continuation.resume(EngineLauncher.ArtemisPatchChoice.ONCE)
-            }
-            .setOnCancelListener {
-                if (continuation.isActive) continuation.resume(null)
-            }
-            .create()
-
-        continuation.invokeOnCancellation { dialog.dismiss() }
-        if (continuation.isActive) {
-            dialog.show()
-            if (!continuation.isActive && dialog.isShowing) dialog.dismiss()
-        }
     }
 
     companion object {


### PR DESCRIPTION
PR #67（已合并）审查后修复的跟进提交：

- 抽取共享 `ArtemisPatchChoiceDialog`（Compose/原生双版本），统一 GameActionsSheet 与桌面快捷方式蹦床的 Artemis 补丁三选逻辑，消除两处语义漂移
- `GameShortcutActivity` 移除配置变更时静默 `finish()`，重建后继续启动流程（修复旋转/进程重建时「点快捷方式无反应」）
- 关闭抽屉时清理裁切弹窗状态，避免 `rememberSaveable` 残留旧弹窗自动弹出
- `requestDesktopShortcut` in-flight 早退时删除新生成的孤儿临时图标
- 补充 exported=true 原因注释（桌面 Launcher 跨进程显式启动所必需）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增 Artemis 补丁选择对话框，支持“总是”“不再”和“本次”三种选择。
  * 统一支持不同界面中的补丁确认流程，取消后不会启动游戏。
* **问题修复**
  * 优化桌面快捷方式重复请求处理，避免生成多余临时图标。
  * 修复配置变更或进程重建后快捷方式启动流程中断的问题。
  * 关闭游戏操作面板时，自动清理相关临时选择状态。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->