### PR TITLE
fix(shortcut): 修复 ArtemisPatchChoiceDialog 缺失 import 导致的编译失败

### DIFF
--- a/app/src/main/java/com/tyranor/next/ui/game/ArtemisPatchChoiceDialog.kt
+++ b/app/src/main/java/com/tyranor/next/ui/game/ArtemisPatchChoiceDialog.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.tyranor.next.R
 import com.tyranor.next.core.game.launch.EngineLauncher
 import com.tyranor.next.core.game.model.ScanGame


### PR DESCRIPTION
紧急修复：PR #68 合并的 ArtemisPatchChoiceDialog.kt 第 63 行使用 `4.dp` 但缺少 `import androidx.compose.ui.unit.dp`，导致 `:app:compileDebugKotlin` 编译失败（BUILD FAILED in 4s）。本 PR 补上该 import。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **修复**
  * 修复界面间距单位无法正确解析的问题。
  * 确保相关对话框的布局间距能够正常显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->