### PR TITLE
fix(launcher): 修复 krkr 应用级字体更换无法生效

### DIFF
--- a/app/src/main/java/com/tyranor/next/core/game/launch/EngineLauncher.kt
+++ b/app/src/main/java/com/tyranor/next/core/game/launch/EngineLauncher.kt
@@ -440,9 +440,12 @@ object EngineLauncher {
                 EngineSettingsStore.KR_126 -> "1.2.6"
                 else -> "1.3.9"
             })
-            // 字体偏好
-            if (defaultFont.isNotEmpty()) putExtra("default_font", defaultFont)
-            if (forceFont) putExtra("force_default_font", true)
+            // 字体偏好：两个 extra 必须无条件注入。引擎侧 applyFontPreferences 仅在
+            // hasExtra 时执行写入/按所有权标记清理——若仅在非空/为真时注入，用户关闭
+            // 强制或清空字体后引擎 XML 里的旧值会永久残留（issue #74「换字体无法生效」
+            // 的根因：残留的 force_default_font=1 一直压住新设置的字体）。
+            putExtra("default_font", defaultFont)
+            putExtra("force_default_font", forceFont)
             // Anime4K 画面超分（单游戏覆盖 > 全局；仅 kirikiri2 内核路径支持）
             val anime4kMode = or(
                 PerGameSettingsStore.getStr(context, gid, PerGameSettingsStore.F_ANIME4K_MODE)

--- a/app/src/main/java/com/tyranor/next/core/game/launch/EngineLauncher.kt
+++ b/app/src/main/java/com/tyranor/next/core/game/launch/EngineLauncher.kt
@@ -248,7 +248,11 @@ object EngineLauncher {
             EngineScanner.isRemovableStoragePath(normalized)
     }
 
-    /** 构建引擎 Intent；path 为真实文件路径。 */
+    /** 构建引擎 Intent；path 为真实文件路径。
+     *  字体偏好契约：`default_font`（空串=引擎按所有权标记清理残留）与
+     *  `force_default_font`（false 写 "0"）**必须无条件注入**——引擎侧
+     *  applyFontPreferences 仅在 hasExtra 时执行写入/清理，缺省会让
+     *  引擎配置里的旧值永久残留（issue #74）。 */
     private fun buildIntent(
         context: Context,
         engine: EngineType,

--- a/app/src/main/java/com/tyranor/next/ui/settings/PerGameSettingsScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/settings/PerGameSettingsScreen.kt
@@ -331,7 +331,9 @@ fun PerGameSettingsScreen(game: ScanGame) {
                         if (!isSdl3) {
                             item {
                                 SectionCard(stringResource(R.string.engine_settings_font)) {
-                                    OverrideFont(stringResource(R.string.engine_settings_default_font), globalKrFont, krFont, onReset = { krFont = "" }, onPick = { fontLauncher.launch("*/*") })
+                                    // 「跟随全局」必须删除覆盖键（null），存 "" 会被引擎当作
+                                    // 显式内置字体覆盖，导致全局字体设置对该游戏永久失效
+                                    OverrideFont(stringResource(R.string.engine_settings_default_font), globalKrFont, krFont, onReset = { krFont = null }, onPick = { fontLauncher.launch("*/*") })
                                     if (effVersion != EngineSettingsStore.KR_126) {
                                         OverrideSwitch(stringResource(R.string.engine_settings_force_default_font_short), globalForce, krForceFont) { krForceFont = it }
                                     }

--- a/app/src/main/java/com/tyranor/next/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/settings/SettingsScreen.kt
@@ -756,6 +756,12 @@ private fun LazyListPlaceholder(
                 FontRow(stringResource(R.string.engine_settings_default_font), krFont.ifEmpty { stringResource(R.string.engine_settings_builtin_font) }, onResetKrFont, { fontLauncher.launch("*/*") })
                 if (krVersion != EngineSettingsStore.KR_126) {
                     SwitchPreference(title = stringResource(R.string.engine_settings_force_default_font), checked = krForceFont, onCheckedChange = onKrForceFont)
+                    Text(
+                        stringResource(R.string.engine_settings_force_font_hint),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MiuixTheme.colorScheme.onBackground,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/tyranor/next/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/tyranor/next/ui/settings/SettingsScreen.kt
@@ -649,6 +649,10 @@ private fun BottomInsetSpacer() {
 
 private typealias FontPickerLauncher = androidx.activity.compose.ManagedActivityResultLauncher<String, Uri?>
 
+/** 引擎设置详情页的滚动列表内容：按 [kind] 渲染对应引擎的设置卡片。
+ *  全部控件仅更新本地状态，统一由顶部保存按钮落盘（编辑→保存模型）。
+ *  KRKR 专属卡片按内核/版本条件显隐：渲染项随 [isSdl3] 切换数据源，
+ *  字体与「操作」卡片仅 kirikiri2 内核显示（krkrsdl3 走命令行参数不生效）。 */
 @Composable
 private fun LazyListPlaceholder(
     kind: EngineSettingsKind,

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -190,6 +190,7 @@
     <string name="engine_settings_default_font">Default font</string>
     <string name="engine_settings_builtin_font">Built-in font</string>
     <string name="engine_settings_force_default_font">Force default font</string>
+    <string name="engine_settings_force_font_hint">When off, only fonts missing from the game are replaced. Enable this to make your chosen font take effect fully</string>
     <string name="engine_settings_force_default_font_short">Force default font</string>
     <string name="engine_settings_fullscreen_stretch">Stretch to fullscreen</string>
     <string name="engine_settings_ignore_cutout">Ignore display cutout</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -190,6 +190,7 @@
     <string name="engine_settings_default_font">既定フォント</string>
     <string name="engine_settings_builtin_font">内蔵フォント</string>
     <string name="engine_settings_force_default_font">既定フォントを強制使用</string>
+    <string name="engine_settings_force_font_hint">オフの場合、ゲームに存在しないフォントのみ置き換えます。変更したフォントを完全に反映するには強制を有効にしてください</string>
     <string name="engine_settings_force_default_font_short">既定フォントを強制</string>
     <string name="engine_settings_fullscreen_stretch">全画面に引き伸ばす</string>
     <string name="engine_settings_ignore_cutout">ノッチを無視</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -190,6 +190,7 @@
     <string name="engine_settings_default_font">默认字体</string>
     <string name="engine_settings_builtin_font">内置字体</string>
     <string name="engine_settings_force_default_font">强制使用默认字体</string>
+    <string name="engine_settings_force_font_hint">未开启时仅替换游戏缺失的字体；要让更换的字体完全生效，请开启强制使用默认字体</string>
     <string name="engine_settings_force_default_font_short">强制默认字体</string>
     <string name="engine_settings_fullscreen_stretch">全屏拉伸</string>
     <string name="engine_settings_ignore_cutout">忽略刘海</string>


### PR DESCRIPTION
## 修改内容

修复应用级引擎设置里更换 krkr2 字体无法生效的问题，并补充设置页说明文字。

## 修改原因

`buildKirikiriIntent` 原本仅在字体路径非空、强制开关为真时才注入 `default_font` / `force_default_font` extras。引擎侧 `applyFontPreferences` 只在 `hasExtra` 时执行写入与按所有权标记清理，导致：

- 用户开启过「强制使用默认字体」再关闭后，引擎配置里 `force_default_font=1` 永久残留，一直强制渲染旧字体，之后在应用级更换任何字体都"无法生效"；
- 清空字体（回到内置字体）后旧 `default_font` 同样残留；
- 引擎侧专门设计的 `_rinne_injected_*` 所有权标记清理路径因 extras 从未出现而永远不会执行。

已在真机用 logcat + 引擎配置文件 dump 逐环验证：修复后设置值可正确覆盖/清理引擎配置。

## 主要改动

- `EngineLauncher.buildKirikiriIntent`：无条件注入 `default_font`（空串触发引擎按所有权标记清理残留）与 `force_default_font`（false 写入 "0" 覆盖残留）
- `SettingsScreen` KRKR 字体卡片：「强制使用默认字体」开关下补充说明文字（引擎语义：未开启时仅替换游戏缺失的字体），三语文案

## 已知边界（非本 PR 范围）

带 **XP3 内嵌字体 + 文字渲染插件**的游戏由游戏脚本直接绑定内嵌字体，`force_default_font` 对其无效——已用独立版 Kirikiroid2 在同一游戏上交叉验证同样不生效，属引擎能力边界。后续可考虑"内嵌字体替换补丁"方向（可基于现有 krkr patch overlay 机制扩展），建议另开 issue 讨论。

## 测试情况

- [x] `./gradlew assembleDebug testDebugUnitTest` 全绿（97 个单测）
- [x] 真机 logcat 逐环验证：App 设置 → Intent 注入 → 引擎 XML 写入（`force_default_font=1` + 字体路径）全部落地
- [x] 开「强制使用默认字体」+ 更换字体：无内嵌字体的 krkr 游戏字体生效
- [x] 关闭强制后引擎配置正确回落 "0"（修复前永久残留 "1"）
- [x] 原有功能正常（渲染器/内核/存档等其他 KRKR 设置注入路径未受影响）

## 相关 Issue

Related #74（根因修复 + 引擎能力边界说明；内嵌字体游戏需另立"字体替换补丁"issue）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 在 KRKR 引擎设置中补充“强制默认字体”说明，明确不同模式下的字体替换范围。
  - 启动游戏时始终应用字体偏好设置，确保所选字体配置正确生效。
  - 补充中文、英文和日文界面文案，帮助用户了解字体设置效果。
- **问题修复**
  - 重置单个游戏的默认字体后，将正确跟随全局字体设置。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->